### PR TITLE
Keep a list of compiled elixir builds with their github revs and date of building

### DIFF
--- a/priv/scripts/otp.sh
+++ b/priv/scripts/otp.sh
@@ -28,7 +28,7 @@ aws s3 cp ${ref_name}.tar.gz s3://s3.hex.pm/builds/otp/${linux}/${ref_name}.tar.
 aws s3 cp s3://s3.hex.pm/builds/otp/${linux}/builds.txt builds.txt || true
 touch builds.txt
 sed -i "/^${ref_name} /d" builds.txt
-echo -e "${ref_name} ${ref}\n$(cat builds.txt)" > builds.txt
+echo -e "${ref_name} ${ref} $(date -u '+%Y-%m-%d %H:%M:%S')\n$(cat builds.txt)" > builds.txt
 sort -u -k1,1 -o builds.txt builds.txt
 aws s3 cp builds.txt s3://s3.hex.pm/builds/otp/${linux}/builds.txt --cache-control "public,max-age=3600" --metadata '{"surrogate-key":"otp-builds","surrogate-control":"public,max-age=604800"}'
 

--- a/priv/scripts/prepare_builds_text.exs
+++ b/priv/scripts/prepare_builds_text.exs
@@ -1,0 +1,51 @@
+defmodule Line do
+  defstruct [:date, :time, :path, :ref, :sha, :otp]
+
+  def from_line(line) do
+    pattern = ~r|builds/elixir/(.*?)(-otp-.*)?\.zip|
+
+    [date, time, _, path] = String.split(line)
+
+    [ref, otp] =
+      case Regex.run(pattern, path, capture: :all_but_first) do
+        [ref] -> [ref, ""]
+        [ref, otp] -> [ref, otp]
+      end
+
+    %Line{
+      date: Date.from_iso8601!(date),
+      time: Time.from_iso8601!(time),
+      path: path,
+      ref: ref,
+      otp: otp
+    }
+  end
+
+  def get_sha(line, repo_dir) do
+    System.cmd("git", ["checkout", line.ref], cd: repo_dir)
+    {sha, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: repo_dir)
+    %{line | sha: String.trim(sha)}
+  end
+
+  def to_builds_txt(line) do
+    [line.ref <> line.otp, line.sha, line.date, line.time] |> Enum.join(" ")
+  end
+end
+
+input = "ls.txt"
+output = "builds.txt"
+repo = "https://github.com/elixir-lang/elixir.git"
+repo_dir = "elixir"
+
+if !File.dir?(repo_dir) do
+  System.cmd("git", ["clone", repo, repo_dir])
+end
+
+content =
+  File.stream!(input)
+  |> Enum.map(&Line.from_line/1)
+  |> Enum.map(&Line.get_sha(&1, repo_dir))
+  |> Enum.map_join("\n", &Line.to_builds_txt/1)
+
+File.write!(output, content)
+{_, 0} = System.cmd("sort", ["-u", "-k1,1", "-o", output, output])


### PR DESCRIPTION
This make is easy to get an overview over which versions are actually available –  instead of chunking together version numbers from https://github.com/hexpm/bob/blob/master/scripts/elixir_to_otp.exs manually – and allows for checking the build commit ref and date of building in case something does not work like e.g. asdf pulling some version it shouldn't.