### PR TITLE
Remove --update flag from apk add command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM hexpm/elixir:1.10.3-erlang-23.0.1-alpine-3.11.6 as build
 
 # install build dependencies
-RUN apk add --no-cache --update git
+RUN apk add --no-cache git
 
 # prepare build dir
 WORKDIR /app


### PR DESCRIPTION
💁 The `--update` (or `--update-cache` as it is currently known) flag for `apk` is intended for a  different purpose than `--no-cache`. Using `--update`/`--update-cache` will retrieve remote package repository indexes and cache them locally, whereas `--no-cache` will explicitly not use any local cache files and only use the remote indexes. Using them both together could produce unexpected results.