### PR TITLE
Build hardening

### DIFF
--- a/priv/scripts/docker/elixir.sh
+++ b/priv/scripts/docker/elixir.sh
@@ -13,6 +13,9 @@ erlang_major=$(echo "${erlang}" | awk 'match($0, /^[0-9][0-9]/) { print substr( 
 
 docker build -t hexpm/elixir-${arch}:${tag} --build-arg ELIXIR=${elixir} --build-arg ERLANG=${erlang} --build-arg ERLANG_MAJOR=${erlang_major} --build-arg OS_VERSION=${os_version} --build-arg ARCH=${arch} -f ${SCRIPT_DIR}/docker/elixir-${os}.dockerfile ${SCRIPT_DIR}/docker
 
+# Smoke test
+docker run hexpm/elixir-${arch}:${tag} elixir -v
+
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/elixir-${arch}:${tag} ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/elixir-${arch}:${tag}) ||

--- a/priv/scripts/docker/elixir.sh
+++ b/priv/scripts/docker/elixir.sh
@@ -14,7 +14,7 @@ erlang_major=$(echo "${erlang}" | awk 'match($0, /^[0-9][0-9]/) { print substr( 
 docker build -t hexpm/elixir-${arch}:${tag} --build-arg ELIXIR=${elixir} --build-arg ERLANG=${erlang} --build-arg ERLANG_MAJOR=${erlang_major} --build-arg OS_VERSION=${os_version} --build-arg ARCH=${arch} -f ${SCRIPT_DIR}/docker/elixir-${os}.dockerfile ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run hexpm/elixir-${arch}:${tag} elixir -v
+docker run --rm hexpm/elixir-${arch}:${tag} elixir -v
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/elixir-${arch}:${tag} ||

--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -4,6 +4,8 @@ FROM alpine:${OS_VERSION} AS build
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie -fstack-clash-protection -fcf-protection=full"
+
 RUN apk --no-cache upgrade
 RUN apk add --no-cache \
   dpkg-dev \

--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -4,7 +4,8 @@ FROM alpine:${OS_VERSION} AS build
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie -fstack-clash-protection -fcf-protection=full"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 -fstack-clash-protection -fcf-protection=full ${PIE_CFLAGS}"
 
 RUN apk --no-cache upgrade
 RUN apk add --no-cache \

--- a/priv/scripts/docker/erlang-debian-buster.dockerfile
+++ b/priv/scripts/docker/erlang-debian-buster.dockerfile
@@ -19,9 +19,12 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie -fstack-protector -fstack-clash-protection -fcf-protection=full"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 -fstack-protector -fstack-clash-protection -fcf-protection=full ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1

--- a/priv/scripts/docker/erlang-debian-buster.dockerfile
+++ b/priv/scripts/docker/erlang-debian-buster.dockerfile
@@ -19,6 +19,10 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie -fstack-protector -fstack-clash-protection -fcf-protection=full"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1
 WORKDIR /OTP

--- a/priv/scripts/docker/erlang-debian-jessie.dockerfile
+++ b/priv/scripts/docker/erlang-debian-jessie.dockerfile
@@ -4,9 +4,12 @@ FROM debian:${OS_VERSION} AS build
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie -fstack-protector"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 -fstack-protector ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN apt-get update
 RUN apt-get -y --no-install-recommends install \

--- a/priv/scripts/docker/erlang-debian-jessie.dockerfile
+++ b/priv/scripts/docker/erlang-debian-jessie.dockerfile
@@ -4,6 +4,10 @@ FROM debian:${OS_VERSION} AS build
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie -fstack-protector"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN apt-get update
 RUN apt-get -y --no-install-recommends install \
   autoconf \

--- a/priv/scripts/docker/erlang-debian-stretch.dockerfile
+++ b/priv/scripts/docker/erlang-debian-stretch.dockerfile
@@ -4,9 +4,12 @@ FROM debian:${OS_VERSION} AS build
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie -fstack-protector"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 -fstack-protector ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN apt-get update
 RUN apt-get -y --no-install-recommends install \

--- a/priv/scripts/docker/erlang-debian-stretch.dockerfile
+++ b/priv/scripts/docker/erlang-debian-stretch.dockerfile
@@ -4,6 +4,10 @@ FROM debian:${OS_VERSION} AS build
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie -fstack-protector"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN apt-get update
 RUN apt-get -y --no-install-recommends install \
   autoconf \

--- a/priv/scripts/docker/erlang-ubuntu-trusty.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-trusty.dockerfile
@@ -19,6 +19,10 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1
 WORKDIR /OTP

--- a/priv/scripts/docker/erlang-ubuntu-trusty.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-trusty.dockerfile
@@ -19,9 +19,12 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1

--- a/priv/scripts/docker/erlang-ubuntu-xenial.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-xenial.dockerfile
@@ -19,6 +19,10 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
+ARG CFLAGS="-g -O2 -fpie"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1
 WORKDIR /OTP

--- a/priv/scripts/docker/erlang-ubuntu-xenial.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-xenial.dockerfile
@@ -19,9 +19,12 @@ RUN apt-get -y --no-install-recommends install \
 
 ARG ERLANG
 
-ARG CFLAGS="-g -O2 -fpie"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -23,10 +23,24 @@ case "${os}" in
     ;;
 esac
 
-docker build -t hexpm/erlang-${arch}:${tag} --build-arg ERLANG=${erlang} --build-arg OS_VERSION=${os_version} -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
+# Disable PIE for OTP prior to 21; see http://erlang.org/doc/apps/hipe/notes.html#hipe-3.18
+pie_cflags="-fpie"
+pie_ldflags="-pie"
+if [ "$(echo ${erlang} | cut -d '.' -f 1)" -le "20" ]; then
+  pie_cflags=""
+  pie_ldflags=""
+fi
+
+docker build \
+  -t hexpm/erlang-${arch}:${tag} \
+  --build-arg ERLANG=${erlang} \
+  --build-arg OS_VERSION=${os_version} \
+  --build-arg PIE_CFLAGS=${pie_cflags} \
+  --build-arg PIE_LDFLAGS=${pie_ldflags} \
+  -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run hexpm/erlang-${arch}:${tag} erl -s erlang halt
+docker run --rm hexpm/erlang-${arch}:${tag} erl -s erlang halt
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -25,6 +25,9 @@ esac
 
 docker build -t hexpm/erlang-${arch}:${tag} --build-arg ERLANG=${erlang} --build-arg OS_VERSION=${os_version} -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
+# Smoke test
+docker run hexpm/erlang-${arch}:${tag} erl -s erlang halt
+
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/erlang-${arch}:${tag}) ||

--- a/priv/scripts/otp/otp-ubuntu-14.04.dockerfile
+++ b/priv/scripts/otp/otp-ubuntu-14.04.dockerfile
@@ -2,9 +2,12 @@ FROM ubuntu:14.04
 
 ENV UBUNTU_VERSION=14.04
 
-ARG CFLAGS="-g -O2 -fpie"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN apt-get update
 
@@ -33,6 +36,10 @@ RUN apt-get install -y \
 
 RUN mkdir -p /home/build/out
 WORKDIR /home/build
+
+ENV CFLAGS=$CFLAGS
+ENV CPPFLAGS=$CPPFLAGS
+ENV LDFLAGS=$LDFLAGS
 
 COPY otp/build_otp_ubuntu.sh /home/build/build.sh
 RUN chmod +x /home/build/build.sh

--- a/priv/scripts/otp/otp-ubuntu-14.04.dockerfile
+++ b/priv/scripts/otp/otp-ubuntu-14.04.dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:14.04
 
 ENV UBUNTU_VERSION=14.04
 
+ARG CFLAGS="-g -O2 -fpie"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN apt-get update
 
 RUN apt-get install -y \

--- a/priv/scripts/otp/otp-ubuntu-16.04.dockerfile
+++ b/priv/scripts/otp/otp-ubuntu-16.04.dockerfile
@@ -2,9 +2,12 @@ FROM ubuntu:16.04
 
 ENV UBUNTU_VERSION=16.04
 
-ARG CFLAGS="-g -O2 -fpie"
+ARG PIE_CFLAGS="-fpie"
+ARG CFLAGS="-g -O2 ${PIE_CFLAGS}"
 ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
-ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
+ARG PIE_LDFLAGS="-pie"
+ARG LDFLAGS="-Wl,-z,relro,-z,now ${PIE_LDFLAGS}"
 
 RUN apt-get update
 
@@ -33,6 +36,10 @@ RUN apt-get install -y \
 
 RUN mkdir -p /home/build/out
 WORKDIR /home/build
+
+ENV CFLAGS=$CFLAGS
+ENV CPPFLAGS=$CPPFLAGS
+ENV LDFLAGS=$LDFLAGS
 
 COPY otp/build_otp_ubuntu.sh /home/build/build.sh
 RUN chmod +x /home/build/build.sh

--- a/priv/scripts/otp/otp-ubuntu-16.04.dockerfile
+++ b/priv/scripts/otp/otp-ubuntu-16.04.dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:16.04
 
 ENV UBUNTU_VERSION=16.04
 
+ARG CFLAGS="-g -O2 -fpie"
+ARG CPPFLAGS="-D_FORTIFY_SOURCE=2"
+ARG LDFLAGS="-pie -Wl,-z,relro,-z,now"
+
 RUN apt-get update
 
 RUN apt-get install -y \


### PR DESCRIPTION
All OTP builds use their respective OS default build flags, which means on older platforms the resulting executables are not sufficiently hardened. In particular, older Ubuntu and Debian versions are not compiled a Position Independent Executable, meaning they cannot take advantage of ASLR. H/T to @unthought for pointing this out.

*Note that I have done very little testing on the resulting binaries. Enabling PIE is known to break HiPE on older OTP versions, but then again, HiPE is broken on the latest OTP versions anyway. I am not aware of any negative impact of other hardening flags, and since the Ubuntu 20.04 build has all flags enabled out of the box it would seem to be safe to apply them elsewhere too...?*

The diffs below show the changes in the output of `hardening-check beam.smp` before and after the Dockerfile changes in this PR. The [hardening-check](http://manpages.ubuntu.com/manpages/focal/man1/hardening-check.1.html) tool is part of the 'devscripts' package on Ubuntu and Debian.

# Ubuntu

## Ubuntu 20.04 (Focal)

No change:
 Position Independent Executable: yes
 Stack protected: yes
 Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: yes
 Stack clash protection: yes
 Control flow integrity: yes

## Ubuntu 18.04 (Bionic)

No change:
 Position Independent Executable: yes
 Stack protected: yes
 Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: yes
 Stack clash protection: unknown, no -fstack-clash-protection instructions found
 Control flow integrity: unknown, no -fcf-protection instructions found!

'Stack clash protection' and 'Control flow integrity' require GCC 8.

## Ubuntu 16.04 (Xenial)

```diff
- Position Independent Executable: no, normal executable!
+ Position Independent Executable: yes
  Stack protected: yes
  Fortify Source functions: yes (some protected functions found)
  Read-only relocations: yes
- Immediate binding: no, not found!
+ Immediate binding: yes
  Stack clash protection: unknown, no -fstack-clash-protection instructions found
  Control flow integrity: unknown, no -fcf-protection instructions found!
```

'Stack clash protection' and 'Control flow integrity' require GCC 8.

## Ubuntu 14.04 (Trusty)

```diff
- Position Independent Executable: no, normal executable!
+ Position Independent Executable: yes
  Stack protected: yes
  Fortify Source functions: yes (some protected functions found)
  Read-only relocations: yes
- Immediate binding: no, not found!
+ Immediate binding: yes
  Stack clash protection: unknown, no -fstack-clash-protection instructions found
  Control flow integrity: unknown, no -fcf-protection instructions found!
```

'Stack clash protection' and 'Control flow integrity' require GCC 8.

# Debian

## Debian 10 (Buster)

```diff
  Position Independent Executable: yes
- Stack protected: no, not found!
- Fortify Source functions: no, only unprotected functions found!
+ Stack protected: yes
+ Fortify Source functions: yes (some protected functions found)
  Read-only relocations: yes
- Immediate binding: no, not found!
- Stack clash protection: unknown, no -fstack-clash-protection instructions found
- Control flow integrity: unknown, no -fcf-protection instructions found!
+ Immediate binding: yes
+ Stack clash protection: yes
+ Control flow integrity: yes
```

## Debian 9 (Stretch)

```diff
  Position Independent Executable: yes
- Stack protected: no, not found!
- Fortify Source functions: no, only unprotected functions found!
+ Stack protected: yes
+ Fortify Source functions: yes (some protected functions found)
  Read-only relocations: yes
- Immediate binding: no, not found!
+ Immediate binding: yes
  Stack clash protection: unknown, no -fstack-clash-protection instructions found
  Control flow integrity: unknown, no -fcf-protection instructions found!
```

'Stack clash protection' and 'Control flow integrity' require GCC 8.

## Debian 8 (Jessie)

```diff
- Position Independent Executable: no, normal executable!
- Stack protected: no, not found!
- Fortify Source functions: no, only unprotected functions found!
- Read-only relocations: no, not found!
- Immediate binding: no, not found!
+ Position Independent Executable: yes
+ Stack protected: yes
+ Fortify Source functions: yes (some protected functions found)
+ Read-only relocations: yes
+ Immediate binding: yes
  Stack clash protection: unknown, no -fstack-clash-protection instructions found
  Control flow integrity: unknown, no -fcf-protection instructions found!
```

'Stack clash protection' and 'Control flow integrity' require GCC 8.

# Alpine

## Alpine 3.12

```diff
  Position Independent Executable: yes
  Stack protected: yes
  Fortify Source functions: no, only unprotected functions found!
  Read-only relocations: yes
  Immediate binding: yes
- Stack clash protection: unknown, no -fstack-clash-protection instructions found
- Control flow integrity: unknown, no -fcf-protection instructions found!
+ Stack clash protection: yes
+ Control flow integrity: yes
```

'Fortify Source functions' not available/applicable in musl.