### PR TITLE
Fix BeamAsm JIT for Alpine

### DIFF
--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -51,7 +51,8 @@ RUN ./configure \
   --with-ssl \
   --enable-threads \
   --enable-dirty-schedulers \
-  --disable-hipe
+  --disable-hipe \
+  --disable-jit
 RUN make -j$(getconf _NPROCESSORS_ONLN)
 RUN make install
 RUN find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf

--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -21,7 +21,8 @@ RUN apk add --no-cache \
   perl-dev \
   wget \
   tar \
-  binutils
+  binutils \
+  libstdc++
 
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1
@@ -51,8 +52,7 @@ RUN ./configure \
   --with-ssl \
   --enable-threads \
   --enable-dirty-schedulers \
-  --disable-hipe \
-  --disable-jit
+  --disable-hipe
 RUN make -j$(getconf _NPROCESSORS_ONLN)
 RUN make install
 RUN find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf

--- a/priv/scripts/otp/build_otp_alpine.sh
+++ b/priv/scripts/otp/build_otp_alpine.sh
@@ -46,8 +46,7 @@ gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"
   --with-ssl \
   --enable-threads \
   --enable-dirty-schedulers \
-  --disable-hipe \
-  --disable-jit
+  --disable-hipe
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make release

--- a/priv/scripts/otp/build_otp_alpine.sh
+++ b/priv/scripts/otp/build_otp_alpine.sh
@@ -46,7 +46,8 @@ gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"
   --with-ssl \
   --enable-threads \
   --enable-dirty-schedulers \
-  --disable-hipe
+  --disable-hipe \
+  --disable-jit
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make release

--- a/priv/scripts/otp/otp-alpine-3.10.dockerfile
+++ b/priv/scripts/otp/otp-alpine-3.10.dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache \
     zlib-dev \
     autoconf \
     build-base \
-    perl-dev
+    perl-dev \
+    libstdc++
 
 RUN mkdir -p /home/build/out
 WORKDIR /home/build


### PR DESCRIPTION
BeamAsm, the JIT variant of BEAM, was merged into OTP master. It appears to require glibc, meaning it breaks on Alpine (musl). Since this is not detected (yet?) by `configure` it does not fall back to building the regular old BEAM. Passing the `--disable-jit` flag ensures a working BEAM is built until the `configure` script is updated (or support for musl is added).

Trying to run Bob Alpine builds, first 23.0.4, then master:

```bash
$ docker run -it --rm alpine:3.10
/ # apk add --update --no-cache ncurses openssl unixodbc lksctp-tools
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/8) Installing liblksctp (1.0.18-r0)
(2/8) Installing lksctp-tools (1.0.18-r0)
(3/8) Installing ncurses-terminfo-base (6.1_p20190518-r2)
(4/8) Installing ncurses-libs (6.1_p20190518-r2)
(5/8) Installing ncurses (6.1_p20190518-r2)
(6/8) Installing openssl (1.1.1g-r0)
(7/8) Installing readline (8.0.0-r0)
(8/8) Installing unixodbc (2.3.7-r1)
Executing busybox-1.30.1-r3.trigger
OK: 8 MiB in 22 packages
/ # wget https://repo.hex.pm/builds/otp/alpine-3.10/OTP-23.0.4.tar.gz
Connecting to repo.hex.pm (151.101.114.2:443)
OTP-23.0.4.tar.gz    100% |************************************************************************| 38.9M  0:00:00 ETA
/ # tar xzf OTP-23.0.4.tar.gz 
/ # cd OTP-23.0.4/
/OTP-23.0.4 # ./Install -minimal $(pwd)

/OTP-23.0.4 # ./erts-11.0.4/bin/erl
Erlang/OTP 23 [erts-11.0.4] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]

Eshell V11.0.4  (abort with ^G)
1> 
BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo
       (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution
^C/OTP-23.0.4 # cd -
/
/ # wget https://repo.hex.pm/builds/otp/alpine-3.10/master.tar.gz
Connecting to repo.hex.pm (151.101.114.2:443)
master.tar.gz        100% |************************************************************************| 46.2M  0:00:00 ETA
/ # tar xzf master.tar.gz 
/ # cd master/
/master # ./Install -minimal $(pwd)

/master # ./erts-11.0.4/bin/erl
Error loading shared library libstdc++.so.6: No such file or directory (needed by /master/erts-11.0.4/bin/beam.smp)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /master/erts-11.0.4/bin/beam.smp)
Error relocating /master/erts-11.0.4/bin/beam.smp: __cxa_begin_catch: symbol not found
Error relocating /master/erts-11.0.4/bin/beam.smp: _Znwm: symbol not found
[...snip...]
Error relocating /master/erts-11.0.4/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /master/erts-11.0.4/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /master/erts-11.0.4/bin/beam.smp: _ZTVN10__cxxabiv121__vmi_class_type_infoE: symbol not found
Error relocating /master/erts-11.0.4/bin/beam.smp: __gxx_personality_v0: symbol not found
/master # 
```