### PR TITLE
Add libstdc++ at runtime only

### DIFF
--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -21,8 +21,7 @@ RUN apk add --no-cache \
   perl-dev \
   wget \
   tar \
-  binutils \
-  libstdc++
+  binutils
 
 RUN mkdir /OTP
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP --strip-components=1
@@ -66,6 +65,7 @@ FROM alpine:${OS_VERSION} AS final
 ARG ERLANG
 
 RUN apk add --update --no-cache \
+  libstdc++ \
   ncurses \
   $(if [ "${ERLANG:0:1}" = "1" ]; then echo "libressl"; else echo "openssl"; fi) \
   unixodbc \

--- a/priv/scripts/otp/otp-alpine-3.10.dockerfile
+++ b/priv/scripts/otp/otp-alpine-3.10.dockerfile
@@ -15,8 +15,7 @@ RUN apk add --no-cache \
     zlib-dev \
     autoconf \
     build-base \
-    perl-dev \
-    libstdc++
+    perl-dev
 
 RUN mkdir -p /home/build/out
 WORKDIR /home/build


### PR DESCRIPTION
Lukas pointed out that libstdc++ is a dependency of build-base, so at compile time it is available. The issue is that it needs to be added as a runtime dependency