### PR TITLE
[fix] Bob.Job.BuildElixir.elixir_to_otp/1 broken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,24 @@ jobs:
       - name: Check mix format
         run: mix format --check-formatted
 
+  warnings:
+    name: Compile warnings check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install OTP and Elixir
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: 23.0.4
+          elixir-version: 1.10.4
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Check compilation warnings
+        run: mix compile --warnings-as-errors
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,24 +21,6 @@ jobs:
       - name: Check mix format
         run: mix format --check-formatted
 
-  warnings:
-    name: Compile warnings check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
-        with:
-          otp-version: 23.0.4
-          elixir-version: 1.10.4
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Check compilation warnings
-        run: mix compile --warnings-as-errors
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -56,6 +38,10 @@ jobs:
         run: |
           mix deps.get
           mix deps.compile
+
+      - name: Check for compiler warnings
+        run: |
+          MIX_ENV=test mix compile --warnings-as-errors
 
       - name: Run tests
         run: |

--- a/lib/bob/job/build_elixir.ex
+++ b/lib/bob/job/build_elixir.ex
@@ -8,8 +8,8 @@ defmodule Bob.Job.BuildElixir do
     Bob.Script.run({:script, "elixir/elixir.sh"}, args, directory)
   end
 
-  defp elixir_to_otp("v" <> version) do
-    version = fix_backport_version(version)
+  def elixir_to_otp(ref_name) do
+    version = ref_to_version(ref_name)
 
     cond do
       version_gte(version, "1.10.3") -> ["21.3", "22.3", "23.0"]
@@ -27,6 +27,8 @@ defmodule Bob.Job.BuildElixir do
     end
   end
 
+  defp version_gte("master", _base), do: true
+
   defp version_gte(version, base_version) do
     case Version.compare(version, base_version) do
       :lt -> false
@@ -34,15 +36,17 @@ defmodule Bob.Job.BuildElixir do
     end
   end
 
-  defp fix_backport_version(version) do
+  defp ref_to_version("v" <> version) do
     # Version.Parser cannot parse backport maintenance tags (eg 1.10)
     # as it doesn't have a patch number.
-    #  we add a large patch to be able to use `Version.compare/2`
+    # we add a large patch to be able to use `Version.compare/2`
     case String.match?(version, ~r/^\d+\.\d+$/) do
       true -> "#{version}.99999"
       _otherwise -> version
     end
   end
+
+  defp ref_to_version(_not_a_version), do: "master"
 
   def priority(), do: 2
   def weight(), do: 3

--- a/test/job/build_elixir_test.exs
+++ b/test/job/build_elixir_test.exs
@@ -16,7 +16,7 @@ defmodule Bob.Job.BuildElixirTest do
       assert BuildElixir.elixir_to_otp("v1.9.4") == BuildElixir.elixir_to_otp("v1.9")
     end
 
-    test "fallbacks to master" do
+    test "falls back to master" do
       assert BuildElixir.elixir_to_otp("master") == BuildElixir.elixir_to_otp("some_other_tag")
     end
   end

--- a/test/job/build_elixir_test.exs
+++ b/test/job/build_elixir_test.exs
@@ -1,0 +1,23 @@
+defmodule Bob.Job.BuildElixirTest do
+  use ExUnit.Case
+
+  alias Bob.Job.BuildElixir
+
+  describe "elixir_to_otp/1" do
+    test "version tags" do
+      assert BuildElixir.elixir_to_otp("v1.10.4") == ["21.3", "22.3", "23.0"]
+    end
+
+    test "rc versions" do
+      assert BuildElixir.elixir_to_otp("v1.10.0-rc.0") == ["21.3", "22.3"]
+    end
+
+    test "backport" do
+      assert BuildElixir.elixir_to_otp("v1.9.4") == BuildElixir.elixir_to_otp("v1.9")
+    end
+
+    test "fallbacks to master" do
+      assert BuildElixir.elixir_to_otp("master") == BuildElixir.elixir_to_otp("some_other_tag")
+    end
+  end
+end


### PR DESCRIPTION
I accidentally broke this in #57

- make `Bob.Job.BuildElixir.elixir_to_otp/1` public again (it's called by `Bob.Job.ElixirChecker`)
- parse "master" ref in `Bob.Job.BuildElixir.elixir_to_otp/1`
- fallback to "master" in `Bob.Job.BuildElixir.elixir_to_otp/1` (same behavior it was before)
- add some tests for it
- add `mix compile --warnings-as-errors` check to github actions workflow