### PR TITLE
Cache DockerHub API calls on startup

### DIFF
--- a/lib/bob/application.ex
+++ b/lib/bob/application.ex
@@ -17,6 +17,7 @@ defmodule Bob.Application do
 
     children = [
       {Task.Supervisor, [name: Bob.Tasks]},
+      Bob.DockerHub.Cache,
       Bob.Queue,
       Bob.Runner,
       {Bob.Schedule, [schedule()]}

--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -17,109 +17,50 @@ defmodule Bob.DockerHub do
   end
 
   def fetch_repo_tags(repo) do
-    (@dockerhub_url <> "v2/repositories/#{repo}/tags?page=${page}&page_size=100")
-    |> dockerhub_request()
+    Bob.DockerHub.Cache.lookup(repo, fn ->
+      (@dockerhub_url <> "v2/repositories/#{repo}/tags?page=${page}&page_size=100")
+      |> dockerhub_request()
+    end)
+  end
+
+  def fetch_tag(repo, tag) do
+    url = @dockerhub_url <> "v2/repositories/#{repo}/tags/#{tag}"
+    headers = headers()
+    opts = [:with_body, recv_timeout: 10_000]
+
+    {:ok, 200, _headers, body} =
+      Bob.HTTP.retry("DockerHub #{url}", fn ->
+        :hackney.request(:get, url, headers, "", opts)
+      end)
+
+    body
+    |> Jason.decode!()
+    |> parse()
+  end
+
+  def headers() do
+    if token = Application.get_env(:bob, :dockerhub_token) do
+      [{"authorization", "JWT #{token}"}]
+    else
+      []
+    end
+  end
+
+  def parse(result) do
+    # Reject corrupt images
+    images = Enum.reject(result["images"], &(&1["digest"] in [nil, ""]))
+
+    if images == [] do
+      nil
+    else
+      # DockerHub returns dupes sometimes?
+      archs = Enum.uniq(Enum.map(result["images"], & &1["architecture"]))
+      {result["name"], archs}
+    end
   end
 
   defp dockerhub_request(url) do
     {:ok, server} = Bob.DockerHub.Pager.start_link(url)
     Bob.DockerHub.Pager.wait(server)
-  end
-
-  defmodule Pager do
-    use GenServer
-    @concurrency 10
-    @timeout 15 * 60_000
-
-    def start_link(url) do
-      GenServer.start_link(__MODULE__, url)
-    end
-
-    def wait(server) do
-      GenServer.call(server, :wait, @timeout)
-    end
-
-    def init(url) do
-      {:ok, next_request(%{url: url, page: 1, tasks: MapSet.new(), results: [], reply: nil})}
-    end
-
-    def handle_call(:wait, from, state) do
-      if MapSet.size(state.tasks) == 0 do
-        {:stop, :normal, Enum.concat(state.results), state}
-      else
-        state = %{state | reply: from}
-        {:noreply, state}
-      end
-    end
-
-    def handle_info({ref, {:ok, result}}, state) do
-      state = %{state | tasks: MapSet.delete(state.tasks, ref), results: [result | state.results]}
-      {:noreply, next_request(state)}
-    end
-
-    def handle_info({ref, :done}, state) do
-      state = %{state | tasks: MapSet.delete(state.tasks, ref)}
-
-      if MapSet.size(state.tasks) == 0 do
-        GenServer.reply(state.reply, Enum.concat(state.results))
-        {:stop, :normal, state}
-      else
-        {:noreply, state}
-      end
-    end
-
-    def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
-      {:noreply, state}
-    end
-
-    defp next_request(state) do
-      if MapSet.size(state.tasks) < @concurrency do
-        task =
-          Task.async(fn ->
-            url = String.replace(state.url, "${page}", Integer.to_string(state.page))
-            opts = [:with_body, recv_timeout: 10_000]
-
-            headers =
-              if token = Application.get_env(:bob, :dockerhub_token) do
-                [{"authorization", "JWT #{token}"}]
-              else
-                []
-              end
-
-            {:ok, 200, _headers, body} =
-              Bob.HTTP.retry("DockerHub #{url}", fn ->
-                :hackney.request(:get, url, headers, "", opts)
-              end)
-
-            body = Jason.decode!(body)
-
-            if body["count"] == 0 do
-              :done
-            else
-              {:ok, parse_response(body["results"])}
-            end
-          end)
-
-        state = %{state | page: state.page + 1, tasks: MapSet.put(state.tasks, task.ref)}
-        next_request(state)
-      else
-        state
-      end
-    end
-
-    defp parse_response(response) do
-      Enum.flat_map(response, fn result ->
-        # Reject corrupt images
-        images = Enum.reject(result["images"], &(&1["digest"] in [nil, ""]))
-
-        if images == [] do
-          []
-        else
-          # DockerHub returns dupes sometimes?
-          archs = Enum.uniq(Enum.map(result["images"], & &1["architecture"]))
-          [{result["name"], archs}]
-        end
-      end)
-    end
   end
 end

--- a/lib/bob/job/build_docker_elixir.ex
+++ b/lib/bob/job/build_docker_elixir.ex
@@ -10,6 +10,13 @@ defmodule Bob.Job.BuildDockerElixir do
       [elixir, erlang, os, os_version, arch],
       directory
     )
+
+    Bob.RemoteQueue.docker_add("elixir-#{arch}", tag(elixir, erlang, os, os_version))
+    Bob.RemoteQueue.add(Bob.Job.DockerManifest, ["elixir", [{elixir, erlang, os, os_version}]])
+  end
+
+  defp tag(elixir, erlang, os, os_version) do
+    "#{elixir}-erlang-#{erlang}-#{os}-#{os_version}"
   end
 
   def priority(), do: 4

--- a/lib/bob/job/build_docker_erlang.ex
+++ b/lib/bob/job/build_docker_erlang.ex
@@ -5,6 +5,13 @@ defmodule Bob.Job.BuildDockerErlang do
     directory = Bob.Directory.new()
     Logger.info("Using directory #{directory}")
     Bob.Script.run({:script, "docker/erlang.sh"}, [erlang, os, os_version, arch], directory)
+
+    Bob.RemoteQueue.docker_add("elixir-#{arch}", tag(erlang, os, os_version))
+    Bob.RemoteQueue.add(Bob.Job.DockerManifest, ["erlang", [{erlang, os, os_version}]])
+  end
+
+  defp tag(erlang, os, os_version) do
+    "#{erlang}-#{os}-#{os_version}"
   end
 
   def priority(), do: 5

--- a/lib/bob/job/docker_manifest.ex
+++ b/lib/bob/job/docker_manifest.ex
@@ -1,16 +1,21 @@
 defmodule Bob.Job.DockerManifest do
   require Logger
 
-  def run(kind, key, archs) do
+  def run(kind, key) do
     directory = Bob.Directory.new()
     Logger.info("Using directory #{directory}")
     tag = key_to_tag(kind, key)
+    archs = get_archs(kind, tag)
 
-    Bob.Script.run(
-      {:script, "docker/manifest.sh"},
-      [kind, tag] ++ archs,
-      directory
-    )
+    if archs == [] do
+      :ok
+    else
+      Bob.Script.run(
+        {:script, "docker/manifest.sh"},
+        [kind, tag] ++ archs,
+        directory
+      )
+    end
   end
 
   defp key_to_tag("erlang", {erlang, os, os_version}) do
@@ -23,4 +28,13 @@ defmodule Bob.Job.DockerManifest do
 
   def priority(), do: 4
   def weight(), do: 4
+
+  defp get_archs(kind, tag) do
+    ["#{kind}-amd64", "#{kind}-arm64"]
+    |> Enum.map(&{&1, Bob.DockerHub.fetch_tag(&1, tag)})
+    |> Enum.flat_map(fn
+      {_repo, nil} -> []
+      {repo, _} -> [repo]
+    end)
+  end
 end

--- a/lib/bob/router.ex
+++ b/lib/bob/router.ex
@@ -38,12 +38,22 @@ defmodule Bob.Router do
   end
 
   post "queue/success" do
-    Bob.Queue.success(conn.params[:id])
+    Bob.Queue.success(conn.params.id)
     send_resp(conn, 204, "")
   end
 
   post "queue/failure" do
-    Bob.Queue.failure(conn.params[:id])
+    Bob.Queue.failure(conn.params.id)
+    send_resp(conn, 204, "")
+  end
+
+  post "queue/add" do
+    Bob.Queue.add(conn.params.module, conn.params.args)
+    send_resp(conn, 204, "")
+  end
+
+  post "docker/add" do
+    Bob.DockerHub.Cache.add(conn.params.repo, conn.params.tag)
     send_resp(conn, 204, "")
   end
 

--- a/lib/docker_hub/cache.ex
+++ b/lib/docker_hub/cache.ex
@@ -1,0 +1,52 @@
+defmodule Bob.DockerHub.Cache do
+  use GenServer
+
+  @timeout 5 * 60_000
+
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    :ets.new(__MODULE__, [:ordered_set, :public, :named_table])
+    {:ok, %{}}
+  end
+
+  def handle_call({:lock, repo}, from, locks) do
+    case Map.fetch(locks, repo) do
+      {:ok, waiting} -> {:noreply, Map.put(locks, repo, [from | waiting])}
+      :error -> {:reply, :aquired, Map.put(locks, repo, [])}
+    end
+  end
+
+  def handle_call({:unlock, repo}, _from, locks) do
+    Enum.each(Map.fetch!(locks, repo), &GenServer.reply(&1, :done))
+    {:reply, :ok, Map.delete(locks, repo)}
+  end
+
+  def add(repo, tag) do
+    :ets.insert(__MODULE__, {{:data, repo, tag}, true})
+  end
+
+  def lookup(repo, fun) do
+    case :ets.lookup(__MODULE__, {:status, repo}) do
+      [] ->
+        case GenServer.call(__MODULE__, {:lock, repo}, @timeout) do
+          :aquired ->
+            result = fun.()
+
+            :ets.insert(__MODULE__, Enum.map(fun.(), &{{:data, repo, &1}, true}))
+            :ets.insert(__MODULE__, {{:status, repo}, true})
+            GenServer.call(__MODULE__, {:unlock, repo})
+
+            result
+
+          :done ->
+            lookup(repo, fun)
+        end
+
+      [{_, true}] ->
+        :ets.select(__MODULE__, [{{{:data, repo, :"$1"}, true}, [], [:"$1"]}])
+    end
+  end
+end

--- a/lib/docker_hub/pager.ex
+++ b/lib/docker_hub/pager.ex
@@ -1,0 +1,76 @@
+defmodule Bob.DockerHub.Pager do
+  use GenServer
+
+  @concurrency 10
+  @timeout 15 * 60_000
+
+  def start_link(url) do
+    GenServer.start_link(__MODULE__, url)
+  end
+
+  def wait(server) do
+    GenServer.call(server, :wait, @timeout)
+  end
+
+  def init(url) do
+    {:ok, next_request(%{url: url, page: 1, tasks: MapSet.new(), results: [], reply: nil})}
+  end
+
+  def handle_call(:wait, from, state) do
+    if MapSet.size(state.tasks) == 0 do
+      {:stop, :normal, Enum.concat(state.results), state}
+    else
+      state = %{state | reply: from}
+      {:noreply, state}
+    end
+  end
+
+  def handle_info({ref, {:ok, result}}, state) do
+    state = %{state | tasks: MapSet.delete(state.tasks, ref), results: [result | state.results]}
+    {:noreply, next_request(state)}
+  end
+
+  def handle_info({ref, :done}, state) do
+    state = %{state | tasks: MapSet.delete(state.tasks, ref)}
+
+    if MapSet.size(state.tasks) == 0 do
+      GenServer.reply(state.reply, Enum.concat(state.results))
+      {:stop, :normal, state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
+  defp next_request(state) do
+    if MapSet.size(state.tasks) < @concurrency do
+      task =
+        Task.async(fn ->
+          url = String.replace(state.url, "${page}", Integer.to_string(state.page))
+          headers = Bob.DockerHub.headers()
+          opts = [:with_body, recv_timeout: 10_000]
+
+          {:ok, 200, _headers, body} =
+            Bob.HTTP.retry("DockerHub #{url}", fn ->
+              :hackney.request(:get, url, headers, "", opts)
+            end)
+
+          body = Jason.decode!(body)
+
+          if body["count"] == 0 do
+            :done
+          else
+            {:ok, Enum.flat_map(body["results"], &List.wrap(Bob.DockerHub.parse(&1)))}
+          end
+        end)
+
+      state = %{state | page: state.page + 1, tasks: MapSet.put(state.tasks, task.ref)}
+      next_request(state)
+    else
+      state
+    end
+  end
+end


### PR DESCRIPTION
Add to cache after BuildDockerErlang and BuildDockerElixir completes.
Additionally queue DockerManifest jobs immediately after BuildDocker
completes to avoid the potential 15min delay.