### PR TITLE
use alpine 3.12 instead of 3.12.1

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -5,7 +5,7 @@ defmodule Bob.Job.DockerChecker do
   @archs ["amd64", "arm64"]
 
   @builds %{
-    "alpine" => ["3.12.1"],
+    "alpine" => ["3.12"],
     "ubuntu" => [
       "groovy-20201022.1",
       "focal-20201008",


### PR DESCRIPTION
What do you think about using the latest `3.12` version of Alpine instead of pinning it? (the current version is `3.12.3`) Or do you prefer pinning it to the exact version? In that case: I could work on a PR to automatically query the latest exact Alpine version, is this something that would be useful?