### PR TITLE
upgrade to alpine 3.13.1

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -5,7 +5,7 @@ defmodule Bob.Job.DockerChecker do
   @archs ["amd64", "arm64"]
 
   @builds %{
-    "alpine" => ["3.12.3"],
+    "alpine" => ["3.13.1"],
     "ubuntu" => [
       "groovy-20201022.1",
       "focal-20201008",


### PR DESCRIPTION
This PR bumps `alpine` to `3.13.1`.