### PR TITLE
Add support for OTP-24 release

### DIFF
--- a/lib/bob/job/build_elixir.ex
+++ b/lib/bob/job/build_elixir.ex
@@ -12,8 +12,8 @@ defmodule Bob.Job.BuildElixir do
     version = ref_to_version(ref_name)
 
     cond do
-      version_gte(version, "1.12.0-0") -> ["22.3", "23.3", "24.0-rc2"]
-      version_gte(version, "1.11.4") -> ["21.3", "22.3", "23.3", "24.0-rc2"]
+      version_gte(version, "1.12.0-0") -> ["22.3", "23.3", "24.0"]
+      version_gte(version, "1.11.4") -> ["21.3", "22.3", "23.3", "24.0"]
       version_gte(version, "1.10.3") -> ["21.3", "22.3", "23.3"]
       version_gte(version, "1.10.0-rc.0") -> ["21.3", "22.3"]
       version_gte(version, "1.8.0-rc.0") -> ["20.3", "21.3", "22.3"]


### PR DESCRIPTION
It appears that [Erlang/OTP 24 was released earlier today](https://github.com/erlang/otp/releases/tag/OTP-24.0), and we're eager to update! I hope this change is sufficient to cause Bob to begin building Elixir 1.11.4 and Elixir 1.12.0 images with OTP-24, but was not certain how to verify this locally.