### PR TITLE
Update docker matrix with alpine 3.12.7 and 3.13.5

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -8,7 +8,8 @@ defmodule Bob.Job.DockerChecker do
 
   @builds %{
     "alpine" => [
-      "3.13.3"
+      "3.12.7",
+      "3.13.5"
     ],
     "ubuntu" => [
       "groovy-20210325",


### PR DESCRIPTION
Running the `hexpm/elixir:1.12.0-erlang-24.0-alpine-3.13.3` image on heroku, it is failing running in Heroku with the following errors.

```
2021-05-19T18:28:52.700825+00:00 app[web.1]: Error loading shared library libstdc++.so.6: No such file or directory (needed by /app/erts-12.0/bin/beam.smp)
2021-05-19T18:28:52.700845+00:00 app[web.1]: Error loading shared library libgcc_s.so.1: No such file or directory (needed by /app/erts-12.0/bin/beam.smp)
2021-05-19T18:28:52.702420+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: __cxa_begin_catch: symbol not found
2021-05-19T18:28:52.702426+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _ZSt24__throw_out_of_range_fmtPKcz: symbol not found
2021-05-19T18:28:52.702487+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _Znwm: symbol not found
2021-05-19T18:28:52.702492+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _ZSt20__throw_length_errorPKc: symbol not found
2021-05-19T18:28:52.702520+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: __cxa_guard_release: symbol not found
2021-05-19T18:28:52.702524+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm: symbol not found
2021-05-19T18:28:52.702553+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: __popcountdi2: symbol not found
2021-05-19T18:28:52.702583+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_: symbol not found
2021-05-19T18:28:52.702587+00:00 app[web.1]: Error relocating /app/erts-12.0/bin/beam.smp: _ZSt17__throw_bad_allocv: symbol not found
```

[This comment](https://github.com/adriankumpf/teslamate/issues/1267#issuecomment-770414340) seems to indicate that the issue is with this version of Alpine, so I have included the previous minor version of Alpine in the matrix, and moved the current minor version to the latest patch. 

Note: I have not run this locally to validate. Waiting on instructions from @ericmj 