### PR TITLE
upgrade to alpine 3.13.5 and 3.14.0

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -8,7 +8,8 @@ defmodule Bob.Job.DockerChecker do
 
   @builds %{
     "alpine" => [
-      "3.13.3"
+      "3.13.5",
+      "3.14.0"
     ],
     "ubuntu" => [
       "groovy-20210325",


### PR DESCRIPTION
version bump for alpine. I included 2 versions of alpine because I wasn't sure if you would want throw everything onto 3.14.0 right away.