### PR TITLE
consider alpine patch differences as well

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -271,7 +271,7 @@ defmodule Bob.Job.DockerChecker do
 
   defp os_diff("alpine", version) do
     version = Version.parse!(version)
-    {version.major, version.minor}
+    {version.major, version.minor, version.patch}
   end
 
   defp os_diff(os, version) when os in ["ubuntu", "debian"] do


### PR DESCRIPTION
Not sure if you'll want this, my main concern is that when the Alpine version gets updated, Bob doesn't use the new Alpine version until there is a new release of Elixir / Erlang. I think it would be nice if when the Alpine gets a patch bump, that the latest images get rebuilt with the new Alpine version.

I'm not super familiar with how Bob determines if it needs to build a particular image version combination, so I fear that this may also cause an explosion of docker images, since it would now be Elixir x Erlang x Alpine patch, instead of Elixir x Erlang x Alpine minor, which I think is the current behavior. If you all don't want this then feel free to close this PR then.
