### PR TITLE
Automatically update the alpine version with the 2 latest minor versions

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,5 @@
 import Config
+
+config :bob,
+  master_schedule: [],
+  agent_schedule: []

--- a/lib/bob/docker_hub/os_versions.ex
+++ b/lib/bob/docker_hub/os_versions.ex
@@ -1,0 +1,28 @@
+defmodule Bob.DockerHub.OSVersions do
+  alias Bob.DockerHub
+
+  # TODO: Automate picking ubuntu and debian os versions
+
+  @static_os_versions %{
+    "ubuntu" => [
+      "groovy-20210325",
+      "focal-20210325",
+      "bionic-20210325",
+      "xenial-20210114",
+      "trusty-20191217"
+    ],
+    "debian" => [
+      "buster-20210326",
+      "stretch-20210326",
+      "jessie-20210326"
+    ]
+  }
+
+  def get_os_versions do
+    Map.put(@static_os_versions, "alpine", get_alpine_versions())
+  end
+
+  defp get_alpine_versions() do
+    DockerHub.OSVersionsSelector.select(:alpine, Bob.DockerHub.fetch_repo_tags("library/alpine"))
+  end
+end

--- a/lib/bob/docker_hub/os_versions_selector.ex
+++ b/lib/bob/docker_hub/os_versions_selector.ex
@@ -1,0 +1,37 @@
+defmodule Bob.DockerHub.OSVersionsSelector do
+  @alpine_minor_versions ["3.14", "3.13"]
+
+  def select(:alpine, tags) do
+    tags
+    |> Enum.map(fn {version, _} -> version end)
+    |> Enum.filter(fn version -> starts_with_any?(version, @alpine_minor_versions) end)
+    |> Enum.flat_map(fn version ->
+      case Version.parse(version) do
+        {:ok, version} -> [version]
+        :error -> []
+      end
+    end)
+    |> Enum.reduce(%{}, fn version, acc ->
+      Map.update(acc, "#{version.major}.#{version.minor}", version, fn current ->
+        higher_version(current, version)
+      end)
+    end)
+    |> Map.values()
+    |> Enum.sort(:desc)
+    |> Enum.map(fn version -> to_string(version) end)
+  end
+
+  defp starts_with_any?(str, prefixes) do
+    Enum.any?(prefixes, fn prefix ->
+      String.starts_with?(str, prefix)
+    end)
+  end
+
+  defp higher_version(version1, version2) do
+    case Version.compare(version1, version2) do
+      :gt -> version1
+      :lt -> version2
+      _ -> version1
+    end
+  end
+end

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -4,27 +4,6 @@ defmodule Bob.Job.DockerChecker do
 
   @archs ["amd64", "arm64"]
 
-  # TODO: Automate picking the OS versions
-
-  @builds %{
-    "alpine" => [
-      "3.13.5",
-      "3.14.0"
-    ],
-    "ubuntu" => [
-      "groovy-20210325",
-      "focal-20210325",
-      "bionic-20210325",
-      "xenial-20210114",
-      "trusty-20191217"
-    ],
-    "debian" => [
-      "buster-20210326",
-      "stretch-20210326",
-      "jessie-20210326"
-    ]
-  }
-
   def run() do
     erlang()
     elixir()
@@ -50,7 +29,7 @@ defmodule Bob.Job.DockerChecker do
   def expected_erlang_tags() do
     refs = erlang_refs()
 
-    for {os, os_versions} <- @builds,
+    for {os, os_versions} <- Bob.DockerHub.OSVersions.get_os_versions(),
         ref <- refs,
         build_erlang_ref?(os, ref),
         os_version <- os_versions,

--- a/test/docker_hub/os_versions_selector_test.exs
+++ b/test/docker_hub/os_versions_selector_test.exs
@@ -1,0 +1,41 @@
+defmodule Bob.DockerHub.OSVersionsSelectorTest do
+  use ExUnit.Case, async: true
+
+  alias Bob.DockerHub.OSVersionsSelector
+
+  describe "select/2" do
+    test "gets the 2 latest alpine versions" do
+      assert OSVersionsSelector.select(:alpine, docker_tags(false)) == ["3.14.0", "3.13.5"]
+    end
+
+    test "doesn't pick up a new alpine minor version" do
+      assert OSVersionsSelector.select(:alpine, docker_tags(true)) == ["3.14.0", "3.13.5"]
+    end
+
+    defp docker_tags(with_new_tags) do
+      new_tags = [
+        {"3.15.0", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]},
+        {"3.15", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]}
+      ]
+
+      docker_tags = [
+        {"latest", ["arm", "arm64", "386", "amd64", "ppc64le", "s390x"]},
+        {"edge", ["arm", "386", "ppc64le", "arm64", "s390x", "amd64"]},
+        {"3.14.0", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]},
+        {"3.14", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]},
+        {"3.13.5", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]},
+        {"3.13.4", ["arm", "amd64", "s390x", "arm64", "386", "ppc64le"]},
+        {"3.13", ["arm", "arm64", "amd64", "ppc64le", "s390x", "386"]},
+        {"3.12.7", ["arm", "386", "ppc64le", "amd64", "arm64", "s390x"]},
+        {"3.12.6", ["arm", "386", "ppc64le", "amd64", "arm64", "s390x"]},
+        {"3.12", ["arm", "s390x", "arm64", "ppc64le", "386", "amd64"]},
+        {"20210212", ["arm", "arm64", "ppc64le", "amd64", "386", "s390x"]},
+        {"3.11.11", ["arm", "arm64", "amd64", "s390x", "ppc64le", "386"]},
+        {"3.11.10", ["arm", "arm64", "amd64", "s390x", "ppc64le", "386"]},
+        {"3.11", ["arm", "s390x", "ppc64le", "386", "amd64", "arm64"]}
+      ]
+
+      if with_new_tags, do: new_tags ++ docker_tags, else: docker_tags
+    end
+  end
+end


### PR DESCRIPTION
This solves part of https://github.com/hexpm/bob/blob/df60a5e20a10e0d17baa9753834bff7920574cbb/lib/bob/job/docker_checker.ex#L7 (it only updates alpine at the moment), but it shouldn't be too difficult to expand this to the ubuntu and debian versions.

I think my tests should be good enough to be sure that it works, but I have a hard time figuring out which images will be built in the docker checker job. I did confirm that it does currently return the same @build var at the current time though, so it should behave properly.

Let me know if you like this approach and I can expand this to include debian and ubuntu as well