### PR TITLE
output erlang version after building erlang docker image

### DIFF
--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -47,7 +47,7 @@ docker build \
   -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run --rm hexpm/erlang-${arch}:${tag} erl -s erlang halt
+docker run --rm hexpm/erlang-${arch}:${tag} erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||


### PR DESCRIPTION
This makes it similar to the elixir script which runs `elixir -v` as its smoke test.