### PR TITLE
Update debian versions

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -19,9 +19,9 @@ defmodule Bob.Job.DockerChecker do
       "trusty-20191217"
     ],
     "debian" => [
-      "buster-20210326",
-      "stretch-20210326",
-      "jessie-20210326"
+      "bullseye-20210816"
+      "buster-20210816",
+      "stretch-20210816"
     ]
   }
 


### PR DESCRIPTION
New Debian release 'bullseye'.

Was not sure if we should keep jessie or not, so I removed and kept only the latest 3.