### PR TITLE
Add Alpine 3.15.0 to the alpine versions

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -8,8 +8,7 @@ defmodule Bob.Job.DockerChecker do
 
   @builds %{
     "alpine" => [
-      "3.13.6",
-      "3.14.2",
+      "3.14.3",
       "3.15.0"
     ],
     "ubuntu" => [

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -9,7 +9,8 @@ defmodule Bob.Job.DockerChecker do
   @builds %{
     "alpine" => [
       "3.13.6",
-      "3.14.2"
+      "3.14.2",
+      "3.15.0"
     ],
     "ubuntu" => [
       "groovy-20210325",


### PR DESCRIPTION
This adds Alpine 3.15.0 to the built Alpine versions. Alpine 3.15 was released as stable on November 24th, and it includes the updated LTS version for NodeJS (v16). 

I noticed in #99 a reference to version smoke tests, but I don't quite see how to run them. I'd be happy to run and triage issues out of the smoke test if I could get a nudge in the right direction.
