### PR TITLE
Upgrade to Alpine 3.14.4 and Alpine 3.15.2

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -8,8 +8,8 @@ defmodule Bob.Job.DockerChecker do
 
   @builds %{
     "alpine" => [
-      "3.14.3",
-      "3.15.0"
+      "3.14.4",
+      "3.15.2"
     ],
     "ubuntu" => [
       "impish-20211102",


### PR DESCRIPTION
These are both minor version bumps for security updates so there shouldn't be any issues.