### PR TITLE
Add Alpine 3.16.0 to supported versions

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -9,7 +9,8 @@ defmodule Bob.Job.DockerChecker do
   @builds %{
     "alpine" => [
       "3.14.6",
-      "3.15.4"
+      "3.15.4",
+      "3.16.0"
     ],
     "ubuntu" => [
       "impish-20211102",


### PR DESCRIPTION
Rather than upgrading this commits add the newest version of alpine
linux. It doesn't look like 3.16.0 contains many breaking changes but I
thought it more prudent.

Apline Announcement: https://alpinelinux.org/posts/Alpine-3.16.0-released.html