### PR TITLE
Build OTP-24.2+ on Ubuntu 22.04 Jammy

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -80,7 +80,10 @@ defmodule Bob.Job.DockerChecker do
   defp build_erlang_ref?("debian", "buster-" <> _, "OTP-1" <> _), do: false
   defp build_erlang_ref?("debian", "bullseye-" <> _, "OTP-1" <> _), do: false
   defp build_erlang_ref?("ubuntu", "focal-" <> _, "OTP-1" <> _), do: false
-  defp build_erlang_ref?("ubuntu", "jammy-" <> _, "OTP-" <> version), do: build_openssl_3?(version)
+
+  defp build_erlang_ref?("ubuntu", "jammy-" <> _, "OTP-" <> version),
+    do: build_openssl_3?(version)
+
   defp build_erlang_ref?(_os, _os_version, _ref), do: true
 
   defp build_erlang_ref?("arm64", "ubuntu", "trusty-" <> _, "OTP-17" <> _), do: false

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -12,7 +12,7 @@ defmodule Bob.Job.DockerChecker do
       "3.15.4"
     ],
     "ubuntu" => [
-      "impish-20211102",
+      "jammy-20220428",
       "focal-20211006",
       "bionic-20210930",
       "xenial-20210804",
@@ -80,7 +80,7 @@ defmodule Bob.Job.DockerChecker do
   defp build_erlang_ref?("debian", "buster-" <> _, "OTP-1" <> _), do: false
   defp build_erlang_ref?("debian", "bullseye-" <> _, "OTP-1" <> _), do: false
   defp build_erlang_ref?("ubuntu", "focal-" <> _, "OTP-1" <> _), do: false
-  defp build_erlang_ref?("ubuntu", "impish-" <> _, "OTP-1" <> _), do: false
+  defp build_erlang_ref?("ubuntu", "jammy-" <> _, "OTP-" <> version), do: build_openssl_3?(version)
   defp build_erlang_ref?(_os, _os_version, _ref), do: true
 
   defp build_erlang_ref?("arm64", "ubuntu", "trusty-" <> _, "OTP-17" <> _), do: false
@@ -116,6 +116,11 @@ defmodule Bob.Job.DockerChecker do
       true ->
         true
     end
+  end
+
+  defp build_openssl_3?(erlang_version) do
+    erlang_version = parse_otp_ref(erlang_version)
+    erlang_version >= [24, 2]
   end
 
   defp parse_otp_ref("OTP-" <> version), do: parse_otp_ref(version)

--- a/lib/bob/job/otp_checker.ex
+++ b/lib/bob/job/otp_checker.ex
@@ -1,6 +1,6 @@
 defmodule Bob.Job.OTPChecker do
   @repo "erlang/otp"
-  @linuxes ["ubuntu-14.04", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04"]
+  @linuxes ["ubuntu-14.04", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04"]
 
   def run(type) do
     for linux <- @linuxes,
@@ -18,8 +18,27 @@ defmodule Bob.Job.OTPChecker do
   defp build_ref?(_type, "ubuntu-20.04", "OTP-17" <> _), do: false
   defp build_ref?(_type, "ubuntu-20.04", "OTP-18" <> _), do: false
   defp build_ref?(_type, "ubuntu-20.04", "OTP-19" <> _), do: false
+  defp build_ref?(_type, "ubuntu-22.04", "OTP-" <> version), do: build_openssl_3?(version)
   defp build_ref?(:tags, _linux, "OTP-" <> _), do: true
   defp build_ref?(:branches, _linux, "maint" <> _), do: true
   defp build_ref?(:branches, _linux, "master" <> _), do: true
   defp build_ref?(_type, _linux, _ref), do: false
+
+  defp build_openssl_3?(erlang_version) do
+    erlang_version = parse_otp_ref(erlang_version)
+    erlang_version >= [24, 2]
+  end
+
+  defp parse_otp_ref(ref) do
+    ref
+    |> String.split("-")
+    |> hd()
+    |> version_to_list()
+  end
+
+  defp version_to_list(version) do
+    version
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
+  end
 end

--- a/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -y --no-install-recommends install \
   autoconf \
   dpkg-dev \
   gcc \
-  gcc-9 \
   g++ \
   make \
   libncurses-dev \
@@ -24,12 +23,11 @@ RUN mkdir -p /OTP/subdir
 RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP/subdir --strip-components=1
 WORKDIR /OTP/subdir
 RUN ./otp_build autoconf
-# Work around "LD: multiple definition of" errors on GCC 10, issue fixed in OTP 22.3
-RUN bash -c 'if [ "${ERLANG:0:1}" = "1" ] || [ "${ERLANG:0:2}" = "20" ] || [ "${ERLANG:0:2}" = "21" ] || [ "${ERLANG:0:2}" = "22" ] ; then CC=gcc-9 ./configure --with-ssl --enable-dirty-schedulers; else ./configure --with-ssl --enable-dirty-schedulers; fi'
+RUN ./configure --with-ssl --enable-dirty-schedulers
 RUN make -j$(getconf _NPROCESSORS_ONLN)
 RUN make install
-RUN bash -c 'if [ "${ERLANG:0:2}" -ge "23" ]; then make docs DOC_TARGETS=chunks; else true; fi'
-RUN bash -c 'if [ "${ERLANG:0:2}" -ge "23" ]; then make install-docs DOC_TARGETS=chunks; else true; fi'
+RUN make docs DOC_TARGETS=chunks
+RUN make install-docs DOC_TARGETS=chunks
 RUN find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf
 RUN find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true
 RUN find /usr/local -name src | xargs -r find | xargs rmdir -vp || true
@@ -43,7 +41,7 @@ ARG ERLANG
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
     libodbc1 \
-    libssl1.1 \
+    libssl3 \
     libsctp1
 
 COPY --from=build /usr/local /usr/local

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -47,7 +47,7 @@ docker build \
   -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run --rm hexpm/erlang-${arch}:${tag} erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+docker run --rm hexpm/erlang-${arch}:${tag} erl -eval 'application:ensure_all_started(ssl),{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -47,7 +47,7 @@ docker build \
   -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run --rm hexpm/erlang-${arch}:${tag} erl -eval 'application:ensure_all_started(ssl),{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+docker run --rm hexpm/erlang-${arch}:${tag} erl -eval '{ok, _} = application:ensure_all_started(ssl),{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||

--- a/priv/scripts/otp/otp-ubuntu-22.04.dockerfile
+++ b/priv/scripts/otp/otp-ubuntu-22.04.dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV UBUNTU_VERSION=22.04
+
+RUN apt-get update
+
+RUN apt-get install -y \
+  wget \
+  ca-certificates \
+  gcc \
+  g++ \
+  make \
+  automake \
+  autoconf \
+  libwxgtk3.0-gtk3-dev \
+  libgl1-mesa-dev \
+  libglu1-mesa-dev \
+  libpng-dev \
+  libreadline-dev \
+  libncurses-dev \
+  libssl-dev \
+  libxslt-dev \
+  libffi-dev \
+  libtool \
+  unixodbc-dev \
+  fop \
+  xsltproc
+
+RUN mkdir -p /home/build/out
+WORKDIR /home/build
+
+COPY otp/build_otp_ubuntu.sh /home/build/build.sh
+RUN chmod +x /home/build/build.sh
+CMD ./build.sh


### PR DESCRIPTION
Closes #112

Should `application:ensure_all_started(ssl)` be added to erlang dockerfile ["smoke test"](https://github.com/hexpm/bob/blob/main/priv/scripts/docker/erlang.sh#L50)? In any case I added it locally and the script succeeded with it for OTP 24.2 and OTP 25.