### PR TITLE
Upgrade debian tags and remove stretch

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -20,12 +20,10 @@ defmodule Bob.Job.DockerChecker do
       "trusty-20191217"
     ],
     "debian" => [
-      "bullseye-20210902",
-      "buster-20210902",
-      "stretch-20210902",
-      "bullseye-20210902-slim",
-      "buster-20210902-slim",
-      "stretch-20210902-slim"
+      "bullseye-20220622",
+      "buster-20220622",
+      "bullseye-20220622-slim",
+      "buster-20220622-slim",
     ]
   }
 

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -23,7 +23,7 @@ defmodule Bob.Job.DockerChecker do
       "bullseye-20220622",
       "buster-20220622",
       "bullseye-20220622-slim",
-      "buster-20220622-slim",
+      "buster-20220622-slim"
     ]
   }
 


### PR DESCRIPTION
Upgrades the debian base images to be more up to date.

Also removes stretch as LTS for that will end at the end of June https://www.debian.org/releases/stretch/