### PR TITLE
Remove main from build_ref?/1

### DIFF
--- a/lib/bob/job/elixir_checker.ex
+++ b/lib/bob/job/elixir_checker.ex
@@ -10,7 +10,6 @@ defmodule Bob.Job.ElixirChecker do
   def priority(), do: 1
   def weight(), do: 1
 
-  defp build_ref?("main"), do: true
   defp build_ref?("v0." <> _), do: false
 
   defp build_ref?("v" <> version) do


### PR DESCRIPTION
Refer to https://github.com/elixir-lang/elixir/pull/12118. We could remove Elixir `main` branch out from Bob.