### PR TITLE
Add debian bookworm to the builds

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -22,8 +22,10 @@ defmodule Bob.Job.DockerChecker do
     "debian" => [
       "bullseye-20220801",
       "buster-20220801",
+      "bookworm-20220912",
       "bullseye-20220801-slim",
-      "buster-20220801-slim"
+      "buster-20220801-slim",
+      "bookworm-20220912-slim"
     ]
   }
 


### PR DESCRIPTION
This would enable installing postgresql-client-14 package which adds SNI support for Postgres connections for easier connection debugging from the containers