### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/priv/scripts/docker/erlang-ubuntu-bionic.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-bionic.dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update && \
   apt-get -y --no-install-recommends install \
     libodbc1 \
     $(bash -c 'if [ "${ERLANG:0:1}" = "1" ]; then echo "libssl1.0.0"; else echo "libssl1.1"; fi') \
-    libsctp1
+    libsctp1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local /usr/local
 ENV LANG=C.UTF-8


### PR DESCRIPTION
Hi!
The Dockerfile placed at "priv/scripts/docker/erlang-ubuntu-bionic.dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance