### PR TITLE
Disable Elixir and Hex build triggers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,14 +8,16 @@ config :bob,
       time: {2, 0, 0},
       queue: true
     ],
-    [
-      module: Bob.Job.ElixirChecker,
-      period: {15, :min}
-    ],
-    [
-      module: Bob.Job.HexDocsChecker,
-      period: {15, :min}
-    ],
+    # Done by https://github.com/elixir-lang/elixir/blob/main/.github/workflows/builds.hex.pm.yml
+    # [
+    #   module: Bob.Job.ElixirChecker,
+    #   period: {15, :min}
+    # ],
+    # Done by https://github.com/hexpm/hex/blob/main/scripts/release.sh
+    # [
+    #   module: Bob.Job.HexDocsChecker,
+    #   period: {15, :min}
+    # ],
     [
       module: Bob.Job.OTPChecker,
       args: [:tags],


### PR DESCRIPTION
Will keep the files around for a while so that we can still trigger manual builds.