### PR TITLE
Ensure CA Cert Bundle is installed

### DIFF
--- a/priv/scripts/docker/erlang-alpine.dockerfile
+++ b/priv/scripts/docker/erlang-alpine.dockerfile
@@ -72,6 +72,7 @@ FROM alpine:${OS_VERSION} AS final
 ARG ERLANG
 
 RUN apk add --update --no-cache \
+  ca-certificates \
   libstdc++ \
   ncurses \
   $(if [ "${ERLANG:0:1}" = "1" ]; then echo "libressl"; else echo "openssl"; fi) \

--- a/priv/scripts/docker/erlang-debian-bullseye.dockerfile
+++ b/priv/scripts/docker/erlang-debian-bullseye.dockerfile
@@ -50,6 +50,7 @@ FROM debian:${OS_VERSION} AS final
 
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
+    ca-certificates \
     libodbc1 \
     libssl1.1 \
     libsctp1 && \

--- a/priv/scripts/docker/erlang-debian-buster.dockerfile
+++ b/priv/scripts/docker/erlang-debian-buster.dockerfile
@@ -47,6 +47,7 @@ FROM debian:${OS_VERSION} AS final
 
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
+    ca-certificates \
     libodbc1 \
     libssl1.1 \
     libsctp1 && \

--- a/priv/scripts/docker/erlang-ubuntu-bionic.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-bionic.dockerfile
@@ -40,6 +40,7 @@ ARG ERLANG
 
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
+    ca-certificates \
     libodbc1 \
     $(bash -c 'if [ "${ERLANG:0:1}" = "1" ]; then echo "libssl1.0.0"; else echo "libssl1.1"; fi') \
     libsctp1 && \

--- a/priv/scripts/docker/erlang-ubuntu-focal.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-focal.dockerfile
@@ -40,6 +40,7 @@ ARG ERLANG
 
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
+    ca-certificates \
     libodbc1 \
     libssl1.1 \
     libsctp1 && \

--- a/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
@@ -40,6 +40,7 @@ ARG ERLANG
 
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
+    ca-certificates \
     libodbc1 \
     libssl3 \
     libsctp1 && \

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -48,7 +48,7 @@ docker build \
   -f ${SCRIPT_DIR}/docker/${dockerfile} ${SCRIPT_DIR}/docker
 
 # Smoke test
-docker run --rm hexpm/erlang-${arch}:${tag} erl -eval '{ok, _} = application:ensure_all_started(ssl),{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+docker run --rm hexpm/erlang-${arch}:${tag} erl -eval '{ok, _} = application:ensure_all_started(ssl),{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), public_key:cacerts_get(), halt().' -noshell
 
 # This command have a tendancy to intermittently fail
 docker push docker.io/hexpm/erlang-${arch}:${tag} ||


### PR DESCRIPTION
Fixes #163

I've decied to add the explicit install instruction everywhere to make the depdendency clear. It was not strictly needed for ubuntu trusty and alpine since the dependency is already implicity installed.

#166 is needed to build the stretch image.