### PR TITLE
Update ubuntu versions

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -14,11 +14,11 @@ defmodule Bob.Job.DockerChecker do
     ],
     "ubuntu" => [
       # 22.04
-      "jammy-20230126",
+      "jammy-20230804",
       # 20.04
-      "focal-20230126",
+      "focal-20230801",
       # 18.04
-      "bionic-20230126"
+      "bionic-20230530"
     ],
     "debian" => [
       # 12


### PR DESCRIPTION
Docker warns that Ubuntu jammy-20230126 has a high-severity vulnerability https://hub.docker.com/layers/library/ubuntu/jammy-20230126/images/sha256-c985bc3f77946b8e92c9a3648c6f31751a7dd972e06604785e47303f4ad47c4c?context=explore

So, bumping to the latest version and, while here, also bumped other versions of ubuntu to the latest available in docker hub

<img width="400" alt="Screenshot 2023-08-21 at 3 03 39 PM" src="https://github.com/hexpm/bob/assets/53276677/7e75d4d1-a698-4510-9cbf-6bbe9b3fc4d4">
