### PR TITLE
Group Erlang build list links by architecture in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ Examples of URLs are:
 
 For lists of builds see:
 
-  * https://builds.hex.pm/builds/otp/amd64/ubuntu-20.04/builds.txt
-  * https://builds.hex.pm/builds/otp/amd64/ubuntu-22.04/builds.txt
-  * https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt
-  * https://builds.hex.pm/builds/otp/arm64/ubuntu-20.04/builds.txt
-  * https://builds.hex.pm/builds/otp/arm64/ubuntu-22.04/builds.txt
-  * https://builds.hex.pm/builds/otp/arm64/ubuntu-24.04/builds.txt
+  * `amd64`:
+    * https://builds.hex.pm/builds/otp/amd64/ubuntu-20.04/builds.txt
+    * https://builds.hex.pm/builds/otp/amd64/ubuntu-22.04/builds.txt
+    * https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt
+  * `arm64`:
+    * https://builds.hex.pm/builds/otp/arm64/ubuntu-20.04/builds.txt
+    * https://builds.hex.pm/builds/otp/arm64/ubuntu-22.04/builds.txt
+    * https://builds.hex.pm/builds/otp/arm64/ubuntu-24.04/builds.txt
 
 ## Docker images
 


### PR DESCRIPTION
It is easy to check the "wrong" list by mistake, amd64 and arm64 look quite similar when not looking too closely. Hopefully this more visual distinction will save some people some time.