### PR TITLE
fix Erlang version parsing

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -238,9 +238,12 @@ defmodule Bob.Job.DockerChecker do
 
   defp to_matchable(string) do
     destructure [version, pre], String.split(string, "-", parts: 2)
-    components = version
-                 |> String.split(".")
-                 |> Enum.map(&String.to_integer/1)
+
+    components =
+      version
+      |> String.split(".")
+      |> Enum.map(&String.to_integer/1)
+
     {components, pre || []}
   end
 

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -238,7 +238,9 @@ defmodule Bob.Job.DockerChecker do
 
   defp to_matchable(string) do
     destructure [version, pre], String.split(string, "-", parts: 2)
-    components = String.split(version, ".")
+    components = version
+                 |> String.split(".")
+                 |> Enum.map(&String.to_integer/1)
     {components, pre || []}
   end
 


### PR DESCRIPTION
Prior to this commit the `erlang_refs` function used to report the latest Erlang/OTP versions for Docker images, was comparing the Erlang version segments lexically, which is fine when each piece contains the same number of digits; however, going from `9` to `10` will also report that `9` is a newer version than `10`. This commit forces the version segments between `OTP-` and any prerelease identifier to be compared as integers instead of Strings.

Example output of `Bob.Job.DockerChecker.erlang_refs/0` before:
```
["OTP-27.0", "OTP-26.2.5", "OTP-26.1.2", "OTP-26.0.2", "OTP-25.3.2.9",
 "OTP-25.2.3", "OTP-25.1.2.1", "OTP-25.0.4", "OTP-24.3.4.9", "OTP-24.2.2",
 "OTP-24.1.7", "OTP-24.0.6", "OTP-23.3.4.9", "OTP-23.2.7.5", "OTP-23.1.5",
 "OTP-23.0.4", "OTP-22.3.4.9", "OTP-22.2.8", "OTP-22.1.8.1", "OTP-22.0.7",
 "OTP-21.3.8.9", "OTP-21.2.7", "OTP-21.1.4", "OTP-21.0.9", "OTP-20.3.8.9",
 "OTP-20.2.4", "OTP-20.1.7.1", "OTP-20.0.5", "OTP-19.3.6.9", "OTP-19.2.3.1",
 "OTP-19.1.6.1", "OTP-19.0.7", "OTP-18.3.4.9", "OTP-18.2.4.1", "OTP-18.1.5",
 "OTP-18.0.3", "OTP-17.5.6.9", "OTP-17.4.1", "OTP-17.3.4", "OTP-17.2.2",
 "OTP-17.1.2", "OTP-17.0.2"]
```
and after:
```
["OTP-27.0", "OTP-26.2.5", "OTP-26.1.2", "OTP-26.0.2", "OTP-25.3.2.12",
 "OTP-25.2.3", "OTP-25.1.2.1", "OTP-25.0.4", "OTP-24.3.4.17", "OTP-24.2.2",
 "OTP-24.1.7", "OTP-24.0.6", "OTP-23.3.4.20", "OTP-23.2.7.5", "OTP-23.1.5",
 "OTP-23.0.4", "OTP-22.3.4.27", "OTP-22.2.8", "OTP-22.1.8.1", "OTP-22.0.7",
 "OTP-21.3.8.24", "OTP-21.2.7", "OTP-21.1.4", "OTP-21.0.9", "OTP-20.3.8.26",
 "OTP-20.2.4", "OTP-20.1.7.1", "OTP-20.0.5", "OTP-19.3.6.13", "OTP-19.2.3.1",
 "OTP-19.1.6.1", "OTP-19.0.7", "OTP-18.3.4.11", "OTP-18.2.4.1", "OTP-18.1.5",
 "OTP-18.0.3", "OTP-17.5.6.10", "OTP-17.4.1", "OTP-17.3.4", "OTP-17.2.2",
 "OTP-17.1.2", "OTP-17.0.2"]
```