### PR TITLE
add 'netbase' dependencie to all debian-based img

### DIFF
--- a/priv/scripts/docker/erlang-debian-bookworm.dockerfile
+++ b/priv/scripts/docker/erlang-debian-bookworm.dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
     ca-certificates \
     libodbc1 \
     libssl3 \
-    libsctp1 && \
+    libsctp1 \
+    netbase && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/priv/scripts/docker/erlang-debian-bullseye.dockerfile
+++ b/priv/scripts/docker/erlang-debian-bullseye.dockerfile
@@ -52,7 +52,8 @@ RUN apt-get update && \
     ca-certificates \
     libodbc1 \
     libssl1.1 \
-    libsctp1 && \
+    libsctp1 \
+    netbase && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/priv/scripts/docker/erlang-debian-buster.dockerfile
+++ b/priv/scripts/docker/erlang-debian-buster.dockerfile
@@ -50,7 +50,8 @@ RUN apt-get update && \
     ca-certificates \
     libodbc1 \
     libssl1.1 \
-    libsctp1 && \
+    libsctp1 \
+    netbase && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/priv/scripts/docker/erlang-ubuntu-focal.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-focal.dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
     ca-certificates \
     libodbc1 \
     libssl1.1 \
-    libsctp1 && \
+    libsctp1 \
+    netbase && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
     ca-certificates \
     libodbc1 \
     libssl3 \
-    libsctp1 && \
+    libsctp1 \
+    netbase && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/priv/scripts/docker/erlang-ubuntu-noble.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-noble.dockerfile
@@ -44,7 +44,8 @@ RUN if [ "${ARCH}" = "amd64" ]; then \
         ca-certificates \
         libodbc2 \
         libssl3t \
-        libsctp1; \
+        libsctp1 \
+        netbase; \
         apt-get clean; \
         rm -rf /var/lib/apt/lists/*; \
     elif [ "${ARCH}" = "arm64" ]; then \
@@ -53,7 +54,8 @@ RUN if [ "${ARCH}" = "amd64" ]; then \
         ca-certificates \
         libodbc2 \
         libssl3t64 \
-        libsctp1; \
+        libsctp1 \
+        netbase; \
         apt-get clean; \
         rm -rf /var/lib/apt/lists/*; \
     fi


### PR DESCRIPTION
This is for #106, add the `netbase` dependency in the final stage of the erlang images, which is missing for the icmp protocol to work in debian/ubuntu images (in alpine it is not needed because it works there).

It was tested running for several random img (trying to grab different versions of ubuntu/debian and elixir/erlang) and it worked on all of them.