### PR TITLE
Build for Alpine 3.21, remove 3.17

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -8,10 +8,10 @@ defmodule Bob.Job.DockerChecker do
     [
       {"alpine",
        [
+         ~r/^3\.21\.\d+$/,
          ~r/^3\.20\.\d+$/,
          ~r/^3\.19\.\d+$/,
-         ~r/^3\.18\.\d+$/,
-         ~r/^3\.17\.\d+$/
+         ~r/^3\.18\.\d+$/
        ]},
       {"ubuntu",
        [


### PR DESCRIPTION
Alpine 3.17 is EOL for a few weeks now, according to: https://endoflife.date/alpine