### PR TITLE
Match "noble-YYYYMMDD.X" Docker tags

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -16,7 +16,7 @@ defmodule Bob.Job.DockerChecker do
       {"ubuntu",
        [
          # 24.04
-         ~r/^noble-\d{8}$/,
+         ~r/^noble-\d{8}(\.\d)?$/,
          # 22.04
          ~r/^jammy-\d{8}$/,
          # 20.04


### PR DESCRIPTION
The latest Ubuntu 24.04 image on Docker Hub has an unusual tag "noble-20241118.1". The suffix ".1" is not common and wasn't part of our original regexp.

This update allows Bob to match the tag and build images based on that Ubuntu version.

Closes #202.