### PR TITLE
Build Elixir against OTP 28

### DIFF
--- a/lib/bob/job/build_elixir.ex
+++ b/lib/bob/job/build_elixir.ex
@@ -16,6 +16,7 @@ defmodule Bob.Job.BuildElixir do
     version = ref_to_version(ref_name)
 
     cond do
+      version_gte(version, "1.18.4") -> ["26.0", "27.0", "28.0"]
       version_gte(version, "1.17.0-0") -> ["25.3", "26.0", "27.0"]
       version_gte(version, "1.15.0-0") -> ["24.3", "25.3", "26.0"]
       version_gte(version, "1.14.4") -> ["23.3", "24.3", "25.3", "26.0"]

--- a/lib/bob/job/build_elixir.ex
+++ b/lib/bob/job/build_elixir.ex
@@ -16,7 +16,7 @@ defmodule Bob.Job.BuildElixir do
     version = ref_to_version(ref_name)
 
     cond do
-      version_gte(version, "1.18.4") -> ["26.0", "27.0", "28.0"]
+      version_gte(version, "1.18.4") -> ["25.3", "26.0", "27.0", "28.0"]
       version_gte(version, "1.17.0-0") -> ["25.3", "26.0", "27.0"]
       version_gte(version, "1.15.0-0") -> ["24.3", "25.3", "26.0"]
       version_gte(version, "1.14.4") -> ["23.3", "24.3", "25.3", "26.0"]


### PR DESCRIPTION
Elixir v1.18.4 was released with initial support for Erlang/OTP 28. https://github.com/elixir-lang/elixir/releases/tag/v1.18.4