### PR TITLE
Return empty map when builds.txt does not exist

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,4 +4,9 @@ config :bob,
   master_schedule: [],
   agent_schedule: []
 
+config :ex_aws,
+  access_key_id: "test",
+  secret_access_key: "test",
+  http_client: Bob.FakeHttpClient
+
 config :logger, level: :warning

--- a/lib/bob/repo.ex
+++ b/lib/bob/repo.ex
@@ -3,10 +3,17 @@ defmodule Bob.Repo do
 
   # TODO: Use S3 object metadata
   def fetch_built_refs(build_path) do
-    Path.join(build_path, "builds.txt")
-    |> fetch_file()
-    |> String.split("\n", trim: true)
-    |> Map.new(&line_to_ref/1)
+    path = Path.join(build_path, "builds.txt")
+
+    case ExAws.S3.get_object(@bucket, path, []) |> ExAws.request() do
+      {:ok, %{body: body}} ->
+        body
+        |> String.split("\n", trim: true)
+        |> Map.new(&line_to_ref/1)
+
+      {:error, {:http_error, 404, _}} ->
+        %{}
+    end
   end
 
   def fetch_file(path) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,10 +7,14 @@ defmodule Bob.Mixfile do
       version: "0.0.1",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       releases: releases(),
       deps: deps()
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application() do
     [

--- a/test/bob/repo_test.exs
+++ b/test/bob/repo_test.exs
@@ -1,0 +1,46 @@
+defmodule Bob.RepoTest do
+  use ExUnit.Case
+
+  alias Bob.Repo
+
+  setup do
+    Bob.FakeHttpClient.reset()
+    :ok
+  end
+
+  describe "fetch_built_refs/1" do
+    test "parses lines into a ref_name => ref map" do
+      body = """
+      OTP-26.2 abc123 2026-01-01T00:00:00Z hash1
+      OTP-27.0 def456 2026-02-01T00:00:00Z hash2
+      """
+
+      Bob.FakeHttpClient.stub(
+        :get,
+        "https://s3.amazonaws.com/s3.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt",
+        200,
+        body
+      )
+
+      assert Repo.fetch_built_refs("builds/otp/amd64/ubuntu-24.04") == %{
+               "OTP-26.2" => "abc123",
+               "OTP-27.0" => "def456"
+             }
+    end
+
+    test "returns an empty map when builds.txt does not exist yet" do
+      assert Repo.fetch_built_refs("builds/otp/amd64/ubuntu-26.04") == %{}
+    end
+
+    test "returns an empty map when builds.txt is empty" do
+      Bob.FakeHttpClient.stub(
+        :get,
+        "https://s3.amazonaws.com/s3.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt",
+        200,
+        ""
+      )
+
+      assert Repo.fetch_built_refs("builds/otp/amd64/ubuntu-24.04") == %{}
+    end
+  end
+end

--- a/test/support/fake_http_client.ex
+++ b/test/support/fake_http_client.ex
@@ -1,0 +1,33 @@
+defmodule Bob.FakeHttpClient do
+  @behaviour ExAws.Request.HttpClient
+
+  @impl true
+  def request(method, url, _body, _headers, _http_opts) do
+    case :persistent_term.get({__MODULE__, {method, url}}, :not_found) do
+      :not_found -> {:ok, %{status_code: 404, headers: [], body: not_found_body(url)}}
+      response -> {:ok, response}
+    end
+  end
+
+  def stub(method, url, status_code, body) do
+    :persistent_term.put(
+      {__MODULE__, {method, url}},
+      %{status_code: status_code, headers: [], body: body}
+    )
+  end
+
+  def reset() do
+    for {{__MODULE__, _key} = key, _value} <- :persistent_term.get() do
+      :persistent_term.erase(key)
+    end
+  end
+
+  defp not_found_body(url) do
+    key = URI.parse(url).path |> String.trim_leading("/")
+
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>#{key}</Key></Error>
+    """
+  end
+end


### PR DESCRIPTION
Bob.Repo.fetch_built_refs/1 raised on S3 404, which caused Bob.Job.OTPChecker to crash for any newly-added OS target (e.g. ubuntu-26.04) before it could queue the first build — a deadlock since builds.txt is only created after the first successful build.

Treat a missing builds.txt as "no refs built yet" and return an empty map, matching the semantics priv/scripts/otp/otp.sh already uses on the write side.