### PR TITLE
Fix ubuntu-26.04 builds

### DIFF
--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -189,8 +189,16 @@ defmodule Bob.Job.DockerChecker do
   end
 
   defp build_ubuntu_26?(erlang_version) do
-    erlang_version = parse_otp_ref(erlang_version)
-    erlang_version >= [26, 0]
+    dev_version? = length(String.split(erlang_version, "-")) > 1
+
+    # C23 compatibility (`bool` keyword)
+    case parse_otp_ref(erlang_version) do
+      [26, 0] ->
+        not dev_version?
+
+      version ->
+        version >= [26, 0]
+    end
   end
 
   defp parse_otp_ref("OTP-" <> version), do: parse_otp_ref(version)

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -189,7 +189,7 @@ defmodule Bob.Job.DockerChecker do
   end
 
   defp build_ubuntu_26?(erlang_version) do
-    dev_version? = length(String.split(erlang_version, "-")) > 1
+    dev_version? = String.contains?(erlang_version, "-")
 
     # C23 compatibility (`bool` keyword)
     case parse_otp_ref(erlang_version) do

--- a/lib/bob/job/otp_checker.ex
+++ b/lib/bob/job/otp_checker.ex
@@ -48,8 +48,16 @@ defmodule Bob.Job.OTPChecker do
   end
 
   defp build_ubuntu_26?(erlang_version) do
-    erlang_version = parse_otp_ref(erlang_version)
-    erlang_version >= [26, 0]
+    dev_version? = length(String.split(erlang_version, "-")) > 1
+
+    # C23 compatibility (`bool` keyword)
+    case parse_otp_ref(erlang_version) do
+      [26, 0] ->
+        not dev_version?
+
+      version ->
+        version >= [26, 0]
+    end
   end
 
   defp parse_otp_ref(ref) do

--- a/lib/bob/job/otp_checker.ex
+++ b/lib/bob/job/otp_checker.ex
@@ -35,7 +35,7 @@ defmodule Bob.Job.OTPChecker do
   end
 
   defp build_ubuntu_24?(erlang_version) do
-    dev_version? = length(String.split(erlang_version, "-")) > 1
+    dev_version? = String.contains?(erlang_version, "-")
 
     # WX compatibility
     case parse_otp_ref(erlang_version) do
@@ -48,7 +48,7 @@ defmodule Bob.Job.OTPChecker do
   end
 
   defp build_ubuntu_26?(erlang_version) do
-    dev_version? = length(String.split(erlang_version, "-")) > 1
+    dev_version? = String.contains?(erlang_version, "-")
 
     # C23 compatibility (`bool` keyword)
     case parse_otp_ref(erlang_version) do

--- a/priv/scripts/docker/erlang-ubuntu-resolute.dockerfile
+++ b/priv/scripts/docker/erlang-ubuntu-resolute.dockerfile
@@ -1,0 +1,50 @@
+ARG OS_VERSION
+
+FROM ubuntu:${OS_VERSION} AS build
+
+RUN apt-get update
+RUN apt-get -y --no-install-recommends install \
+  autoconf \
+  dpkg-dev \
+  gcc \
+  g++ \
+  make \
+  libncurses-dev \
+  unixodbc-dev \
+  libssl-dev \
+  libsctp-dev \
+  wget \
+  ca-certificates \
+  pax-utils
+
+ARG ERLANG
+
+RUN mkdir -p /OTP/subdir
+RUN wget -nv "https://github.com/erlang/otp/archive/OTP-${ERLANG}.tar.gz" && tar -zxf "OTP-${ERLANG}.tar.gz" -C /OTP/subdir --strip-components=1
+WORKDIR /OTP/subdir
+RUN ./otp_build autoconf
+RUN ./configure --with-ssl --enable-dirty-schedulers
+RUN make -j$(getconf _NPROCESSORS_ONLN)
+RUN make -j$(getconf _NPROCESSORS_ONLN) install
+RUN make -j$(getconf _NPROCESSORS_ONLN) docs DOC_TARGETS=chunks
+RUN make -j$(getconf _NPROCESSORS_ONLN) install-docs DOC_TARGETS=chunks
+RUN find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf
+RUN find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true
+RUN find /usr/local -name src | xargs -r find | xargs rmdir -vp || true
+RUN scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all
+RUN scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded
+
+FROM ubuntu:${OS_VERSION} AS final
+
+RUN apt-get update; \
+    apt-get -y --no-install-recommends install \
+      ca-certificates \
+      libodbc2 \
+      libssl3t64 \
+      libsctp1 \
+      netbase; \
+      apt-get clean; \
+      rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local /usr/local
+ENV LANG=C.UTF-8


### PR DESCRIPTION
Add the missing erlang-ubuntu-resolute.dockerfile so docker builds for Ubuntu 26.04 can resolve their dockerfile, and skip OTP-26.0 RCs which fail to compile against the C23 default GCC ships in Ubuntu 26.04.