### PR TITLE
Build 1.19 against OTP 29

### DIFF
--- a/lib/bob/job/build_elixir.ex
+++ b/lib/bob/job/build_elixir.ex
@@ -16,7 +16,7 @@ defmodule Bob.Job.BuildElixir do
     version = ref_to_version(ref_name)
 
     cond do
-      version_gte(version, "1.19.0-0") -> ["26.0", "27.0", "28.0"]
+      version_gte(version, "1.19.0-0") -> ["26.0", "27.0", "28.0", "29.0"]
       version_gte(version, "1.18.4-0") -> ["25.3", "26.0", "27.0", "28.0"]
       version_gte(version, "1.17.0-0") -> ["25.3", "26.0", "27.0"]
       version_gte(version, "1.15.0-0") -> ["24.3", "25.3", "26.0"]


### PR DESCRIPTION
I'm not sure if this is the best way to approach this, but in my FreeBSD pkg overlay Elixir 1.19.5 builds fine against Erlang 29.0. I don't see any builds (apart from 1.20 rcs) currently available for OTP 29.