### PR TITLE
Use buildx imagetools to assemble multi-arch manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,12 @@ FROM debian:${DEBIAN_VERSION} AS app
 RUN apt update -y && \
     apt install --no-install-recommends -y apt-transport-https awscli bash build-essential ca-certificates coreutils curl docker.io gnupg gzip libffi-dev libssl-dev openssl pigz python3-dev tar zip
 
+ARG BUILDX_VERSION=0.17.1
+RUN mkdir -p /usr/libexec/docker/cli-plugins && \
+    curl -fsSL "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-$(dpkg --print-architecture)" \
+      -o /usr/libexec/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/libexec/docker/cli-plugins/docker-buildx
+
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt update -y && apt install --no-install-recommends -y google-cloud-cli

--- a/priv/scripts/docker/manifest.sh
+++ b/priv/scripts/docker/manifest.sh
@@ -6,8 +6,6 @@ kind=$1
 tag=$2
 archs=(${@:3})
 
-export DOCKER_CLI_EXPERIMENTAL=enabled
-
 arch_images=""
 
 for arch in "${archs[@]}"; do
@@ -16,16 +14,9 @@ done
 
 # These commands have a tendancy to intermittently fail
 
-docker manifest create --amend hexpm/${kind}:${tag} ${arch_images} ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest create --amend hexpm/${kind}:${tag} ${arch_images}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest create --amend hexpm/${kind}:${tag} ${arch_images}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest create --amend hexpm/${kind}:${tag} ${arch_images}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest create --amend hexpm/${kind}:${tag} ${arch_images}) ||
-  (exit 1)
-
-docker manifest push --purge hexpm/${kind}:${tag} ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest push --purge hexpm/${kind}:${tag}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest push --purge hexpm/${kind}:${tag}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest push --purge hexpm/${kind}:${tag}) ||
-  (sleep $((10 + $RANDOM % 20)) && docker manifest push --purge hexpm/${kind}:${tag}) ||
+docker buildx imagetools create -t hexpm/${kind}:${tag} ${arch_images} ||
+  (sleep $((10 + $RANDOM % 20)) && docker buildx imagetools create -t hexpm/${kind}:${tag} ${arch_images}) ||
+  (sleep $((10 + $RANDOM % 20)) && docker buildx imagetools create -t hexpm/${kind}:${tag} ${arch_images}) ||
+  (sleep $((10 + $RANDOM % 20)) && docker buildx imagetools create -t hexpm/${kind}:${tag} ${arch_images}) ||
+  (sleep $((10 + $RANDOM % 20)) && docker buildx imagetools create -t hexpm/${kind}:${tag} ${arch_images}) ||
   (exit 1)


### PR DESCRIPTION
docker manifest push re-serializes each child manifest before upload. The amd64 per-arch images are pushed by buildx with 2-space indented JSON while the legacy docker manifest tool re-marshals to 3-space, changing the bytes and therefore the digest. The pushed child landed under a new digest while the manifest list still referenced the original, so the registry rejected the list with "manifest blob unknown: blob unknown to registry".

docker buildx imagetools create copies children by digest without re-serializing, so digests stay stable. It also keeps no local manifest store, avoiding the unbounded growth of ~/.docker/manifests left behind by "docker manifest push --purge" on failed pushes.

Install the buildx CLI plugin in the app image since it only shipped Debian's docker.io package without buildx.