### PR TITLE
Retry HTTP requests on server errors

### DIFF
--- a/lib/bob/http.ex
+++ b/lib/bob/http.ex
@@ -33,6 +33,17 @@ defmodule Bob.HTTP do
           result
         end
 
+      {:ok, status, _headers, _body} = result when status >= 500 ->
+        Logger.warning("#{name} SERVER ERROR: #{status}")
+
+        if times + 1 < @max_retry_times do
+          sleep = trunc(:math.pow(3, times) * @error_sleep_time)
+          Process.sleep(sleep)
+          retry(name, fun, times + 1)
+        else
+          result
+        end
+
       result ->
         result
     end

--- a/test/bob/http_test.exs
+++ b/test/bob/http_test.exs
@@ -1,0 +1,33 @@
+defmodule Bob.HTTPTest do
+  use ExUnit.Case
+
+  alias Bob.HTTP
+
+  defp counter(responses) do
+    {:ok, agent} = Agent.start_link(fn -> responses end)
+
+    fn ->
+      Agent.get_and_update(agent, fn [response | rest] -> {response, rest} end)
+    end
+  end
+
+  test "returns successful responses without retrying" do
+    fun = counter([{:ok, 200, [], "body"}])
+    assert HTTP.retry("test", fun) == {:ok, 200, [], "body"}
+  end
+
+  test "retries on server errors until success" do
+    fun = counter([{:ok, 502, [], ""}, {:ok, 500, [], ""}, {:ok, 200, [], "ok"}])
+    assert HTTP.retry("test", fun) == {:ok, 200, [], "ok"}
+  end
+
+  test "retries on transport errors until success" do
+    fun = counter([{:error, :closed}, {:ok, 200, [], "ok"}])
+    assert HTTP.retry("test", fun) == {:ok, 200, [], "ok"}
+  end
+
+  test "does not retry client errors" do
+    fun = counter([{:ok, 404, [], ""}])
+    assert HTTP.retry("test", fun) == {:ok, 404, [], ""}
+  end
+end


### PR DESCRIPTION
Treat 5xx responses like transport errors and retry them with the same exponential backoff, instead of surfacing them to the caller immediately.