### PR TITLE
Fix Postgres query failures exposed by the persistent-state backfill

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -90,7 +90,8 @@ defmodule Bob.Artifacts do
           DO UPDATE SET archs = EXCLUDED.archs, built_at = EXCLUDED.built_at, updated_at = EXCLUDED.updated_at
           WHERE docker_tags.archs IS DISTINCT FROM EXCLUDED.archs
           """,
-          [token, repo, now]
+          [token, repo, now],
+          timeout: @swap_timeout
         )
 
         Repo.query!(
@@ -102,12 +103,14 @@ defmodule Bob.Artifacts do
               WHERE s.token = $1 AND s.repo = d.repo AND s.tag = d.tag
             )
           """,
-          [token, repo]
+          [token, repo],
+          timeout: @swap_timeout
         )
 
         Repo.query!(
           "DELETE FROM docker_tags_staging WHERE token = $1 AND repo = $2",
-          [token, repo]
+          [token, repo],
+          timeout: @swap_timeout
         )
       end,
       timeout: @swap_timeout

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -122,6 +122,21 @@ defmodule Bob.Artifacts do
     :ok
   end
 
+  @doc """
+  Whether any tag is staged under `token` for `repo`. `EXISTS` stops at the
+  first matching row via the `(token, repo, tag)` index, so this stays cheap even
+  when a full repo (~1M rows) is staged — unlike counting every distinct tag.
+  """
+  def staged_any?(token, repo) do
+    %{rows: [[exists?]]} =
+      Repo.query!(
+        "SELECT EXISTS(SELECT 1 FROM docker_tags_staging WHERE token = $1 AND repo = $2)",
+        [token, repo]
+      )
+
+    exists?
+  end
+
   @doc "Number of distinct tags staged under `token` for `repo`."
   def staged_tag_count(token, repo) do
     %{rows: [[count]]} =

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -10,9 +10,12 @@ defmodule Bob.Artifacts do
   # so a page is inserted in chunks well under that ceiling.
   @staging_chunk 5000
 
-  # The swap reads and rewrites the whole repo (up to ~1M rows for hexpm/elixir)
-  # in two set-based statements, which can run longer than the 15s default.
-  @swap_timeout 5 * 60 * 1000
+  # Reconcile/backfill rewrites a repo's entire tag set through
+  # docker_tags_staging (up to ~1M rows for hexpm/elixir). Queries over that full
+  # set can run longer than Postgrex's 15s default, so each passes this timeout
+  # explicitly — a transaction's :timeout does not propagate to the queries it
+  # wraps.
+  @long_query_timeout 5 * 60 * 1000
 
   def add(attrs) do
     upsert(attrs)
@@ -91,7 +94,7 @@ defmodule Bob.Artifacts do
           WHERE docker_tags.archs IS DISTINCT FROM EXCLUDED.archs
           """,
           [token, repo, now],
-          timeout: @swap_timeout
+          timeout: @long_query_timeout
         )
 
         Repo.query!(
@@ -104,16 +107,16 @@ defmodule Bob.Artifacts do
             )
           """,
           [token, repo],
-          timeout: @swap_timeout
+          timeout: @long_query_timeout
         )
 
         Repo.query!(
           "DELETE FROM docker_tags_staging WHERE token = $1 AND repo = $2",
           [token, repo],
-          timeout: @swap_timeout
+          timeout: @long_query_timeout
         )
       end,
-      timeout: @swap_timeout
+      timeout: @long_query_timeout
     )
 
     :ok
@@ -124,7 +127,8 @@ defmodule Bob.Artifacts do
     %{rows: [[count]]} =
       Repo.query!(
         "SELECT count(DISTINCT tag) FROM docker_tags_staging WHERE token = $1 AND repo = $2",
-        [token, repo]
+        [token, repo],
+        timeout: @long_query_timeout
       )
 
     count
@@ -135,7 +139,8 @@ defmodule Bob.Artifacts do
     %{rows: rows} =
       Repo.query!(
         "SELECT DISTINCT tag FROM docker_tags_staging WHERE token = $1 AND repo = $2 AND archs @> $3",
-        [token, repo, archs]
+        [token, repo, archs],
+        timeout: @long_query_timeout
       )
 
     Enum.map(rows, fn [tag] -> tag end)
@@ -143,7 +148,10 @@ defmodule Bob.Artifacts do
 
   @doc "Drops every staging row for `token` (used when a fetch fails partway)."
   def discard_staging(token) do
-    Repo.query!("DELETE FROM docker_tags_staging WHERE token = $1", [token])
+    Repo.query!("DELETE FROM docker_tags_staging WHERE token = $1", [token],
+      timeout: @long_query_timeout
+    )
+
     :ok
   end
 
@@ -158,7 +166,9 @@ defmodule Bob.Artifacts do
       |> NaiveDateTime.add(-older_than_seconds, :second)
 
     %{num_rows: num_rows} =
-      Repo.query!("DELETE FROM docker_tags_staging WHERE inserted_at < $1", [cutoff])
+      Repo.query!("DELETE FROM docker_tags_staging WHERE inserted_at < $1", [cutoff],
+        timeout: @long_query_timeout
+      )
 
     num_rows
   end

--- a/lib/bob/queue.ex
+++ b/lib/bob/queue.ex
@@ -20,6 +20,10 @@ defmodule Bob.Queue do
   @dedup_conflict_target {:unsafe_fragment,
                           "(module_key, args_digest) WHERE state IN ('queued', 'running')"}
 
+  # Postgres rejects a statement with more than 65535 bind parameters. Each row
+  # inserted below binds 6 fields, so chunk inserts to stay under that ceiling.
+  @insert_chunk_size div(65_535, 6)
+
   def add(key, args) do
     add_many([{key, args}])
   end
@@ -46,12 +50,14 @@ defmodule Bob.Queue do
         }
       end)
 
-    if rows != [] do
-      Repo.insert_all(Job, rows,
+    rows
+    |> Enum.chunk_every(@insert_chunk_size)
+    |> Enum.each(fn chunk ->
+      Repo.insert_all(Job, chunk,
         on_conflict: :nothing,
         conflict_target: @dedup_conflict_target
       )
-    end
+    end)
 
     :ok
   end

--- a/lib/bob/reconcile.ex
+++ b/lib/bob/reconcile.ex
@@ -97,7 +97,7 @@ defmodule Bob.Reconcile do
 
   defp swap_docker_tags(stream, repo, transform) do
     stage(stream, repo, transform, fn token ->
-      if Artifacts.staged_tag_count(token, repo) > 0 do
+      if Artifacts.staged_any?(token, repo) do
         Artifacts.swap_docker_tags(token, repo)
       else
         Logger.warning("RECONCILE empty fetch for #{repo}, skipping")

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -293,6 +293,17 @@ defmodule Bob.ArtifactsTest do
     end
   end
 
+  describe "staged_any?/2" do
+    test "is true only when a tag is staged for the token and repo" do
+      token = Ecto.UUID.generate()
+      Artifacts.stage_docker_tags(token, "hexpm/erlang-amd64", [{"a", ["amd64"]}])
+
+      assert Artifacts.staged_any?(token, "hexpm/erlang-amd64")
+      refute Artifacts.staged_any?(token, "hexpm/elixir-amd64")
+      refute Artifacts.staged_any?(Ecto.UUID.generate(), "hexpm/erlang-amd64")
+    end
+  end
+
   describe "staged_tag_count/2" do
     test "counts distinct staged tags for the token and repo" do
       token = Ecto.UUID.generate()

--- a/test/bob/queue_test.exs
+++ b/test/bob/queue_test.exs
@@ -179,6 +179,16 @@ defmodule Bob.QueueTest do
     assert size(TestJob) == 2
   end
 
+  test "add_many chunks inserts that exceed the Postgres bind-parameter limit" do
+    # Each row binds 6 fields, so more than 65535 / 6 rows would overflow a
+    # single insert statement. Chunking must keep every row enqueued.
+    count = div(65_535, 6) + 1
+    entries = for i <- 1..count, do: {TestJob, [i]}
+
+    Queue.add_many(entries)
+    assert size(TestJob) == count
+  end
+
   test "queue_sizes counts queued jobs per key" do
     Queue.add(TestJob, [:a])
     Queue.add(TestJob, [:b])


### PR DESCRIPTION
DB-layer fixes surfaced by the master booting against an empty database and running the initial backfill.

**1. Chunk `Queue.add_many/1` inserts** — every row was inserted in a single `Repo.insert_all`. Each row binds 6 fields, so enqueuing more than 65535 / 6 ≈ 10922 rows overflows Postgres's 65535 bind-parameter cap and raises `Postgrex.QueryError`. `DockerChecker.manifest/0` diffed against empty state and tried to enqueue ~34k jobs (204492 parameters), crashing the checker (BOB-23). Rows are now chunked under the limit.

**2. Apply a long query timeout to every full-staging-set reconcile query** — `swap_docker_tags/2`, `staged_tag_count/2`, `staged_multi_arch_tags/3`, `discard_staging/1` and `prune_staging/1` each scan, rewrite, or delete the whole `docker_tags_staging` set (up to ~1M rows for hexpm/elixir). The 5-minute timeout was only on the `swap` transaction, but in Ecto a transaction's `:timeout` does not propagate to the `Repo.query!` calls it wraps — those fall back to the 15s default, exceed it on the first backfill, and db_connection cancels the statement / closes the connection (`57014 query_canceled`, then `ssl recv: closed`). The timeout (renamed `@swap_timeout` → `@long_query_timeout`) is now passed to each query.

**3. Replace the pre-swap count with an EXISTS probe** — the swap guard only needs to know whether anything was staged, but it computed `count(DISTINCT tag)` over the whole staging set. `staged_any?/2` uses `EXISTS`, which the `(token, repo, tag)` index satisfies with a single seek instead of scanning ~1M rows.

No new indexes: the staging table is already indexed on `(token, repo, tag)` and `(inserted_at)`, which cover every access path here. The remaining cost (the swap upsert and prune anti-join) is inherent to rewriting a full repo's tags and is a one-time cutover expense.