### PR TITLE
Implement job callbacks on Bob.Job.ReconcileBaseImages

### DIFF
--- a/lib/bob/job/reconcile_base_images.ex
+++ b/lib/bob/job/reconcile_base_images.ex
@@ -2,4 +2,8 @@ defmodule Bob.Job.ReconcileBaseImages do
   def run() do
     Bob.Reconcile.reconcile_base_images()
   end
+
+  def priority(), do: 1
+  def weight(), do: 1
+  def concurrency(), do: :shared
 end

--- a/test/bob/remote_queue_test.exs
+++ b/test/bob/remote_queue_test.exs
@@ -65,5 +65,17 @@ defmodule Bob.RemoteQueueTest do
       assert [{_id1, SharedTestJob, [:arg1]}, {_id2, UnsharedTestJob, [:arg1]}] =
                RemoteQueue.start_jobs([SharedTestJob, UnsharedTestJob], 5, %{})
     end
+
+    test "starts every queued master checker job (each implements the job contract)" do
+      for module <- [
+            Bob.Job.OTPChecker,
+            Bob.Job.DockerChecker,
+            Bob.Job.Reconcile,
+            Bob.Job.ReconcileBaseImages
+          ] do
+        Bob.Queue.add(module, [])
+        assert [{_id, ^module, []}] = RemoteQueue.start_jobs([module], 100, %{})
+      end
+    end
   end
 end


### PR DESCRIPTION
`Bob.Job.ReconcileBaseImages` is scheduled with `queue: true` but only defines `run/0` — it is missing `priority/0`, `weight/0`, and `concurrency/0`. The queue's `prioritize/1` calls `priority()` on every module in a node's job list each cycle, so the job can never be processed: it sits in the queue, and adding it to `BOB_LOCAL_JOBS` would crash the whole local-queue loop (taking `DockerChecker` down with it).

Surfaced after the persistent-state cutover: with the schedule now enqueuing `OTPChecker`, `Reconcile`, and `ReconcileBaseImages` (`queue: true`), `queue_sizes()` showed `OTPChecker` and `ReconcileBaseImages` stuck at 1 because the master's `BOB_LOCAL_JOBS` doesn't list them — and `ReconcileBaseImages` couldn't be added until it implements the contract.

Add the three callbacks to match `Bob.Job.Reconcile`. Regression test drives each queued master checker through `RemoteQueue.start_jobs/3` (the crash path).