### PR TITLE
Dispatch the runner queue by node role so agents never use the repo

### DIFF
--- a/lib/bob/runner.ex
+++ b/lib/bob/runner.ex
@@ -9,11 +9,13 @@ defmodule Bob.Runner do
     GenServer.start_link(__MODULE__, new_state(), name: __MODULE__)
   end
 
+  # The master owns the Postgres-backed queue and runs jobs from it. Agents have
+  # no Bob.Repo and only pull work from the master over HTTP, so they must never
+  # touch the local queue. Dispatch every poll on the node's role.
   def init(state) do
     if Application.get_env(:bob, :master?) do
       Process.send_after(self(), :local_timeout, 0)
     else
-      Process.send_after(self(), :local_timeout, 0)
       Process.send_after(self(), :remote_timeout, 0)
     end
 
@@ -92,9 +94,11 @@ defmodule Bob.Runner do
   defp apply_task(module, fun, args), do: apply(module, fun, args)
 
   defp start_any_jobs(state) do
-    state
-    |> start_jobs(&Bob.RemoteQueue.local_queue/2)
-    |> start_jobs(&Bob.RemoteQueue.remote_queue/2)
+    if Application.get_env(:bob, :master?) do
+      start_jobs(state, &Bob.RemoteQueue.local_queue/2)
+    else
+      start_jobs(state, &Bob.RemoteQueue.remote_queue/2)
+    end
   end
 
   defp start_jobs(state, fun) do

--- a/test/bob/runner_test.exs
+++ b/test/bob/runner_test.exs
@@ -1,0 +1,104 @@
+defmodule Bob.RunnerTest do
+  # async: false — these tests start a named Bob.Runner and the agent block stops
+  # the shared Bob.Repo, so they must not run alongside anything else.
+  use ExUnit.Case, async: false
+
+  defmodule QuietJob do
+    def run(), do: :ok
+    def priority(), do: 1
+    def weight(), do: 1
+    def concurrency(), do: :shared
+  end
+
+  setup do
+    on_exit(fn ->
+      case Process.whereis(Bob.Runner) do
+        nil -> :ok
+        pid -> Process.exit(pid, :kill)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "master node" do
+    setup do
+      owner = Ecto.Adapters.SQL.Sandbox.start_owner!(Bob.Repo, shared: true)
+      on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(owner) end)
+
+      previous = Application.get_env(:bob, :local_jobs)
+      Application.put_env(:bob, :local_jobs, [QuietJob])
+      on_exit(fn -> Application.put_env(:bob, :local_jobs, previous) end)
+
+      :ok
+    end
+
+    test "claims a queued job from the local (repo-backed) queue" do
+      Bob.Queue.add(QuietJob, [])
+
+      {:ok, runner} = Bob.Runner.start_link([])
+      send(runner, :local_timeout)
+      # Flush the mailbox so the :local_timeout tick has been processed.
+      :sys.get_state(runner)
+
+      assert Bob.Queue.start(QuietJob) == :error
+    end
+  end
+
+  describe "agent node (no repo)" do
+    setup do
+      previous = %{
+        master?: Application.get_env(:bob, :master?),
+        local_jobs: Application.get_env(:bob, :local_jobs),
+        remote_jobs: Application.get_env(:bob, :remote_jobs)
+      }
+
+      # Mimic an agent: Bob.Repo is never started there, so take it down here. A
+      # non-empty local_jobs makes the regression observable — the old code polled
+      # the local queue, which would reach the stopped repo and crash.
+      :ok = Supervisor.terminate_child(Bob.Supervisor, Bob.Repo)
+      Application.put_env(:bob, :master?, false)
+      Application.put_env(:bob, :local_jobs, [QuietJob])
+      Application.put_env(:bob, :remote_jobs, [])
+
+      on_exit(fn ->
+        {:ok, _} = Supervisor.restart_child(Bob.Supervisor, Bob.Repo)
+        Ecto.Adapters.SQL.Sandbox.mode(Bob.Repo, :manual)
+        Application.put_env(:bob, :master?, previous.master?)
+        Application.put_env(:bob, :local_jobs, previous.local_jobs)
+        Application.put_env(:bob, :remote_jobs, previous.remote_jobs)
+      end)
+
+      :ok
+    end
+
+    test "the database really is unavailable (test premise)" do
+      assert_raise RuntimeError, ~r/could not lookup Ecto repo/, fn ->
+        Bob.Queue.queue_sizes()
+      end
+    end
+
+    test "polls for work on startup without touching the database" do
+      Process.flag(:trap_exit, true)
+
+      {:ok, runner} = Bob.Runner.start_link([])
+
+      # init/1 drives the agent poll loop. With the regression it also polled the
+      # local queue, crashing on the stopped repo and exiting the linked runner.
+      refute_receive {:EXIT, ^runner, _reason}, 200
+      assert Process.alive?(runner)
+    end
+
+    test "re-polls after a job completes without touching the database" do
+      Process.flag(:trap_exit, true)
+
+      {:ok, runner} = Bob.Runner.start_link([])
+      assert Bob.Runner.run(QuietJob, []) == :ok
+
+      # Completing a job triggers another poll; on an agent that must stay off the
+      # local (repo-backed) queue.
+      refute_receive {:EXIT, ^runner, _reason}, 300
+      assert Process.alive?(runner)
+    end
+  end
+end


### PR DESCRIPTION
`Bob.Runner` polled **both** the local Postgres-backed queue and the remote master queue on every node — `init/1` scheduled a local poll on agents, and `start_any_jobs/1` ran both after each job. Agents have no `Bob.Repo` (it only starts on master nodes), so once the queue became Postgres-backed the local poll raised `could not lookup Ecto repo Bob.Repo` and crash-looped the agent. The `BOB_LOCAL_JOBS=[]` config change stopped the bleeding; this closes the footgun in code.

Dispatch the queue by `master?`: the master runs its local queue, agents only pull from the master over HTTP. An agent now never calls `Bob.Queue`, regardless of its `BOB_LOCAL_JOBS`.

**Testing the no-repo path.** The normal suite always has `Bob.Repo` running (it starts because `master?` defaults to true in tests), so an agent that reaches for the database sails through. `Bob.RunnerTest` adds an "agent node" block that **stops `Bob.Repo`** and sets `master? = false` with a non-empty `local_jobs`, so the old behavior is observable: the runner crashes on the stopped repo. A premise test asserts the database really is down. Reverting the fix turns both agent tests red with the exact production error; with the fix the full suite is green (145 tests).