### PR TITLE
Single-instance schedule ticks via a Postgres ledger

### DIFF
--- a/lib/bob/schedule.ex
+++ b/lib/bob/schedule.ex
@@ -30,7 +30,9 @@ defmodule Bob.Schedule do
 
   def handle_info({:run, module, args, time, period, queue?} = message, _) do
     if queue? do
-      Bob.Queue.add(module, args || [])
+      if Bob.Schedule.Ledger.claim(module, args || [], period) do
+        Bob.Queue.add(module, args || [])
+      end
     else
       Bob.Runner.run(module, args || [])
     end

--- a/lib/bob/schedule/ledger.ex
+++ b/lib/bob/schedule/ledger.ex
@@ -1,0 +1,51 @@
+defmodule Bob.Schedule.Ledger do
+  @moduledoc """
+  Arbitrates schedule ticks between master instances. Every master fires its
+  own timers, but a tick may only be enqueued by the instance that claims it
+  here first; further claims are rejected until the entry's period has elapsed
+  since the last successful claim.
+  """
+
+  alias Bob.Queue.Term
+  alias Bob.Repo
+
+  @seconds_min 60
+  @seconds_hour 60 * 60
+  @seconds_day 60 * 60 * 24
+
+  # Timers drift slightly between instances and across restarts, so accept
+  # claims marginally before a full period has elapsed.
+  @grace_max 60
+
+  def claim(key, args, period, now \\ DateTime.utc_now()) do
+    threshold = DateTime.add(now, -threshold_seconds(period), :second)
+
+    {:ok, %{rows: rows}} =
+      Repo.query(
+        """
+        INSERT INTO schedule_ledger (module_key, args_digest, last_run_at, inserted_at, updated_at)
+        VALUES ($1, $2, $3, $3, $3)
+        ON CONFLICT (module_key, args_digest)
+        DO UPDATE SET last_run_at = $3, updated_at = $3
+        WHERE schedule_ledger.last_run_at <= $4
+        RETURNING schedule_ledger.id
+        """,
+        [Term.encode(key), Term.digest(args), now, threshold]
+      )
+
+    rows != []
+  end
+
+  defp threshold_seconds(period) do
+    seconds = period_seconds(period)
+    seconds - min(@grace_max, div(seconds, 10))
+  end
+
+  defp period_seconds({num, :day}), do: num * @seconds_day
+  defp period_seconds({num, :hour}), do: num * @seconds_hour
+  defp period_seconds({num, :min}), do: num * @seconds_min
+  defp period_seconds({num, :sec}), do: num
+  defp period_seconds(:day), do: @seconds_day
+  defp period_seconds(:hour), do: @seconds_hour
+  defp period_seconds(:min), do: @seconds_min
+end

--- a/priv/repo/migrations/20260610210000_create_schedule_ledger.exs
+++ b/priv/repo/migrations/20260610210000_create_schedule_ledger.exs
@@ -1,0 +1,14 @@
+defmodule Bob.Repo.Migrations.CreateScheduleLedger do
+  use Ecto.Migration
+
+  def change do
+    create table(:schedule_ledger) do
+      add :module_key, :binary, null: false
+      add :args_digest, :binary, null: false
+      add :last_run_at, :utc_datetime_usec, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:schedule_ledger, [:module_key, :args_digest])
+  end
+end

--- a/test/bob/schedule/ledger_test.exs
+++ b/test/bob/schedule/ledger_test.exs
@@ -1,0 +1,61 @@
+defmodule Bob.Schedule.LedgerTest do
+  use Bob.DataCase
+
+  alias Bob.Schedule.Ledger
+
+  defmodule TestJob do
+  end
+
+  @period {15, :min}
+  @period_seconds 15 * 60
+
+  test "claims the first tick" do
+    assert Ledger.claim(TestJob, [], @period)
+  end
+
+  test "rejects further claims within the period" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [], @period, now)
+    refute Ledger.claim(TestJob, [], @period, now)
+    refute Ledger.claim(TestJob, [], @period, DateTime.add(now, 60, :second))
+    refute Ledger.claim(TestJob, [], @period, DateTime.add(now, div(@period_seconds, 2), :second))
+  end
+
+  test "claims again once the period has elapsed" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [], @period, now)
+    assert Ledger.claim(TestJob, [], @period, DateTime.add(now, @period_seconds, :second))
+  end
+
+  test "accepts claims slightly early to absorb timer drift" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [], @period, now)
+    assert Ledger.claim(TestJob, [], @period, DateTime.add(now, @period_seconds - 30, :second))
+  end
+
+  test "claims are independent per args" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [:a], @period, now)
+    assert Ledger.claim(TestJob, [:b], @period, now)
+    refute Ledger.claim(TestJob, [:a], @period, now)
+  end
+
+  test "claims are independent per module" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [], @period, now)
+    assert Ledger.claim(Bob.Job.OTPChecker, [], @period, now)
+  end
+
+  test "supports bare atom periods" do
+    now = DateTime.utc_now()
+
+    assert Ledger.claim(TestJob, [], :day, now)
+    refute Ledger.claim(TestJob, [], :day, DateTime.add(now, 12 * 60 * 60, :second))
+    assert Ledger.claim(TestJob, [], :day, DateTime.add(now, 24 * 60 * 60, :second))
+  end
+end

--- a/test/bob/schedule_test.exs
+++ b/test/bob/schedule_test.exs
@@ -1,0 +1,30 @@
+defmodule Bob.ScheduleTest do
+  use Bob.DataCase
+
+  defmodule TestJob do
+    def priority(), do: 1
+    def weight(), do: 1
+    def concurrency(), do: :shared
+  end
+
+  test "concurrent schedulers enqueue a tick only once" do
+    message = {:run, TestJob, [], nil, {15, :min}, true}
+
+    Bob.Schedule.handle_info(message, [])
+    Bob.Schedule.handle_info(message, [])
+
+    assert [{TestJob, []}] = Bob.Queue.queued()
+  end
+
+  test "a tick is not re-enqueued after the job completed within the period" do
+    message = {:run, TestJob, [], nil, {15, :min}, true}
+
+    Bob.Schedule.handle_info(message, [])
+    {:ok, {id, []}} = Bob.Queue.start(TestJob)
+    Bob.Queue.success(id)
+
+    Bob.Schedule.handle_info(message, [])
+
+    assert Bob.Queue.queued() == []
+  end
+end


### PR DESCRIPTION
Every master runs the scheduler, so with more than one instance each periodic job was enqueued once per instance: timers are phase-shifted by instance start times, and once the first tick's job completes the active-job dedup index no longer suppresses the second insert, roughly doubling the cadence of periodic jobs.

Queued schedule ticks must now claim an atomic per-entry slot in the schedule_ledger table before enqueueing; claims are rejected until the entry's period (minus a small drift grace) has elapsed since the last successful claim. If the claiming instance dies, another instance takes over within one period.