### PR TITLE
Diff expected Docker tags in SQL instead of loading full tag history

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -388,6 +388,73 @@ defmodule Bob.Artifacts do
     )
   end
 
+  @doc """
+  The subset of `tags` that exist for `repo`, as a set.
+
+  The checker probes its (small) expected tag set with this instead of loading
+  a repo's full tag history; the lookup runs on the unique `(repo, tag)` index.
+  """
+  def docker_tags_present(_repo, []), do: MapSet.new()
+
+  def docker_tags_present(repo, tags) do
+    Repo.all(
+      from(d in DockerTag,
+        where: d.repo == ^repo and d.tag in ^tags,
+        select: d.tag
+      ),
+      timeout: @long_query_timeout
+    )
+    |> MapSet.new()
+  end
+
+  @doc """
+  `{repo, tag}` for every tag of `repos` whose search metadata carries one of
+  `os_versions`. Scopes the checker's erlang reads to current base images —
+  a fraction of the full history.
+  """
+  def erlang_tags_for_os_versions(repos, os_versions) do
+    Repo.all(
+      from(d in DockerTag,
+        where:
+          d.repo in ^repos and
+            fragment("?->>'os_version' = ANY(?)", d.search, ^os_versions),
+        select: {d.repo, d.tag}
+      ),
+      timeout: @long_query_timeout
+    )
+  end
+
+  @doc """
+  `{tag, archs}` for every per-arch tag whose manifest is missing or lacks one
+  of the built archs. The whole diff runs in Postgres; only mismatches (normally
+  none) reach the caller. Tags that exist only in the manifest repo are ignored,
+  as is a manifest carrying more archs than were built.
+  """
+  def manifest_mismatches(manifest_repo, amd64_repo, arm64_repo) do
+    # The ::text[] cast is required: archs is varchar[] and array containment
+    # does not unify varchar[] with the aggregated text[].
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT p.tag, p.archs
+        FROM (
+          SELECT tag,
+                 array_agg(DISTINCT CASE WHEN repo = $2 THEN 'amd64' ELSE 'arm64' END) AS archs
+          FROM docker_tags
+          WHERE repo IN ($2, $3)
+          GROUP BY tag
+        ) AS p
+        LEFT JOIN docker_tags m ON m.repo = $1 AND m.tag = p.tag
+        WHERE m.id IS NULL OR NOT (m.archs::text[] @> p.archs)
+        ORDER BY p.tag COLLATE "C"
+        """,
+        [manifest_repo, amd64_repo, arm64_repo],
+        timeout: @long_query_timeout
+      )
+
+    Enum.map(rows, fn [tag, archs] -> {tag, archs} end)
+  end
+
   def base_image_tags(repo) do
     Repo.all(
       from(b in BaseImageTag,

--- a/lib/bob/github.ex
+++ b/lib/bob/github.ex
@@ -2,8 +2,8 @@ defmodule Bob.GitHub do
   @github_url "https://api.github.com/"
 
   def fetch_repo_refs(repo) do
-    branches = github_request(@github_url <> "repos/#{repo}/branches")
-    tags = github_request(@github_url <> "repos/#{repo}/tags")
+    branches = github_request(@github_url <> "repos/#{repo}/branches?per_page=100")
+    tags = github_request(@github_url <> "repos/#{repo}/tags?per_page=100")
     response_to_refs(branches) ++ response_to_refs(tags)
   end
 

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -1,8 +1,11 @@
 defmodule Bob.Job.DockerChecker do
+  require Logger
+
   @erlang_tag_regex ~r"^(.+)-(alpine|ubuntu|debian)-(.+)$"
   @elixir_tag_regex ~r"^(.+)-erlang-(.+)-(alpine|ubuntu|debian)-(.+)$"
 
   @archs ["amd64", "arm64"]
+  @erlang_arch_repos Enum.map(@archs, &"hexpm/erlang-#{&1}")
 
   def builds() do
     [
@@ -64,12 +67,24 @@ defmodule Bob.Job.DockerChecker do
   def concurrency(), do: :shared
 
   def erlang() do
-    diff(expected_erlang_tags(), erlang_tags())
+    expected_erlang_tags()
+    |> Enum.group_by(fn {_erlang, _os, _os_version, arch} -> arch end)
+    |> Enum.flat_map(fn {arch, expected} ->
+      present =
+        Bob.Artifacts.docker_tags_present(
+          "hexpm/erlang-#{arch}",
+          Enum.map(expected, &erlang_tag_name/1)
+        )
+
+      Enum.reject(expected, &MapSet.member?(present, erlang_tag_name(&1)))
+    end)
     |> Enum.map(fn {erlang, os, os_version, arch} ->
       {{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}
     end)
     |> Bob.Queue.add_many()
   end
+
+  defp erlang_tag_name({erlang, os, os_version, _arch}), do: "#{erlang}-#{os}-#{os_version}"
 
   def expected_erlang_tags() do
     refs = erlang_refs()
@@ -254,32 +269,33 @@ defmodule Bob.Job.DockerChecker do
     {components, pre || []}
   end
 
-  def erlang_tags() do
-    Enum.flat_map(@archs, &erlang_tags/1)
-  end
-
-  def erlang_tags(arch) do
-    "hexpm/erlang-#{arch}"
-    |> Bob.Artifacts.docker_tags()
-    |> Enum.map(fn {tag, [^arch]} ->
-      [erlang, os, os_version] = Regex.run(@erlang_tag_regex, tag, capture: :all_but_first)
-      {erlang, os, os_version, arch}
-    end)
-  end
-
   def elixir() do
-    diff(expected_elixir_tags(), elixir_tags())
+    expected_elixir_tags()
+    |> Enum.group_by(fn {_elixir, _erlang, _os, _os_version, arch} -> arch end)
+    |> Enum.flat_map(fn {arch, expected} ->
+      present =
+        Bob.Artifacts.docker_tags_present(
+          "hexpm/elixir-#{arch}",
+          Enum.map(expected, &elixir_tag_name/1)
+        )
+
+      Enum.reject(expected, &MapSet.member?(present, elixir_tag_name(&1)))
+    end)
     |> Enum.map(fn {elixir, erlang, os, os_version, arch} ->
       {{Bob.Job.BuildDockerElixir, arch}, [elixir, erlang, os, os_version]}
     end)
     |> Bob.Queue.add_many()
   end
 
+  defp elixir_tag_name({elixir, erlang, os, os_version, _arch}) do
+    "#{elixir}-erlang-#{erlang}-#{os}-#{os_version}"
+  end
+
   def expected_elixir_tags() do
     builds = builds()
     refs = elixir_builds()
 
-    Stream.flat_map(erlang_tags(), fn {erlang, os, os_version, erlang_arch} ->
+    Stream.flat_map(current_erlang_tags(builds), fn {erlang, os, os_version, erlang_arch} ->
       if not skip_elixir_for_erlang?(erlang) and os_version in builds[os] do
         Stream.flat_map(refs, fn {"v" <> elixir, otp_major} ->
           if compatible_elixir_and_erlang?(otp_major, erlang) do
@@ -294,6 +310,20 @@ defmodule Bob.Job.DockerChecker do
     end)
   end
 
+  # Erlang per-arch tags scoped to the current base-image os_versions — the
+  # only ones expected_elixir_tags/0 can use. Rows returned here always carry
+  # search metadata, so the tag is guaranteed to match @erlang_tag_regex.
+  defp current_erlang_tags(builds) do
+    os_versions = builds |> Map.values() |> List.flatten()
+
+    @erlang_arch_repos
+    |> Bob.Artifacts.erlang_tags_for_os_versions(os_versions)
+    |> Enum.map(fn {"hexpm/erlang-" <> arch, tag} ->
+      [erlang, os, os_version] = Regex.run(@erlang_tag_regex, tag, capture: :all_but_first)
+      {erlang, os, os_version, arch}
+    end)
+  end
+
   def elixir_builds() do
     "builds/elixir"
     |> Bob.Store.fetch_built_refs()
@@ -303,21 +333,6 @@ defmodule Bob.Job.DockerChecker do
     |> Enum.sort(&cmp_elixir_tags/2)
     |> Enum.reject(fn {_elixir, otp} -> otp == nil end)
     |> Enum.reject(fn {"v" <> elixir, _otp} -> skip_elixir?(elixir) end)
-  end
-
-  def elixir_tags() do
-    Stream.flat_map(@archs, &elixir_tags/1)
-  end
-
-  def elixir_tags(arch) do
-    "hexpm/elixir-#{arch}"
-    |> Bob.Artifacts.docker_tags()
-    |> Enum.map(fn {tag, [^arch]} ->
-      [elixir, erlang, os, os_version] =
-        Regex.run(@elixir_tag_regex, tag, capture: :all_but_first)
-
-      {elixir, erlang, os, os_version, arch}
-    end)
   end
 
   defp split_elixir_build(build_name) do
@@ -358,18 +373,6 @@ defmodule Bob.Job.DockerChecker do
     end
   end
 
-  def diff(expected, current) do
-    current = MapSet.new(current)
-
-    Stream.flat_map(expected, fn key ->
-      if MapSet.member?(current, key) do
-        []
-      else
-        [key]
-      end
-    end)
-  end
-
   defp compatible_elixir_and_erlang?(otp_major, erlang) do
     String.starts_with?(erlang, otp_major <> ".")
   end
@@ -386,53 +389,39 @@ defmodule Bob.Job.DockerChecker do
   end
 
   def manifest() do
-    erlang_tags = group_archs(erlang_tags())
-    erlang_manifest_tags = erlang_manifest_tags()
-    diff_manifests("erlang", erlang_tags, erlang_manifest_tags)
-
-    elixir_tags = group_archs(elixir_tags())
-    elixir_manifest_tags = elixir_manifest_tags()
-    diff_manifests("elixir", elixir_tags, elixir_manifest_tags)
+    check_manifests("erlang")
+    check_manifests("elixir")
   end
 
-  def erlang_manifest_tags() do
-    "hexpm/erlang"
-    |> Bob.Artifacts.docker_tags()
-    |> Map.new(fn {tag, archs} ->
-      [erlang, os, os_version] = Regex.run(@erlang_tag_regex, tag, capture: :all_but_first)
-      {{erlang, os, os_version}, archs}
-    end)
-  end
+  # The whole per-arch vs manifest diff runs in Postgres; only mismatched tags
+  # (normally none) come back, so just those few need parsing into job args.
+  defp check_manifests(kind) do
+    "hexpm/#{kind}"
+    |> Bob.Artifacts.manifest_mismatches("hexpm/#{kind}-amd64", "hexpm/#{kind}-arm64")
+    |> Enum.flat_map(fn {tag, _archs} ->
+      case manifest_key(kind, tag) do
+        {:ok, key} ->
+          [{Bob.Job.DockerManifest, [kind, key]}]
 
-  def elixir_manifest_tags() do
-    "hexpm/elixir"
-    |> Bob.Artifacts.docker_tags()
-    |> Map.new(fn {tag, archs} ->
-      [elixir, erlang, os, os_version] =
-        Regex.run(@elixir_tag_regex, tag, capture: :all_but_first)
-
-      {{elixir, erlang, os, os_version}, archs}
-    end)
-  end
-
-  def group_archs(enum) do
-    Enum.group_by(
-      enum,
-      &Tuple.delete_at(&1, tuple_size(&1) - 1),
-      &elem(&1, tuple_size(&1) - 1)
-    )
-  end
-
-  def diff_manifests(kind, expected, current) do
-    expected
-    |> Enum.sort()
-    |> Enum.flat_map(fn {key, expected_archs} ->
-      if expected_archs -- Map.get(current, key, []) != [] do
-        [{Bob.Job.DockerManifest, [kind, key]}]
-      else
-        []
+        :error ->
+          Logger.error("DOCKER CHECKER skipping unparseable #{kind} tag #{inspect(tag)}")
+          []
       end
     end)
     |> Bob.Queue.add_many()
+  end
+
+  defp manifest_key("erlang", tag) do
+    case Regex.run(@erlang_tag_regex, tag, capture: :all_but_first) do
+      [erlang, os, os_version] -> {:ok, {erlang, os, os_version}}
+      nil -> :error
+    end
+  end
+
+  defp manifest_key("elixir", tag) do
+    case Regex.run(@elixir_tag_regex, tag, capture: :all_but_first) do
+      [elixir, erlang, os, os_version] -> {:ok, {elixir, erlang, os, os_version}}
+      nil -> :error
+    end
   end
 end

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -481,16 +481,117 @@ defmodule Bob.ArtifactsTest do
     end
   end
 
-  describe "docker_tags/1" do
-    test "scopes to the requested repo" do
-      Artifacts.add_docker_tag("hexpm/erlang-amd64", "a", ["amd64"])
-      Artifacts.add_docker_tag("hexpm/erlang-arm64", "b", ["arm64"])
+  describe "docker_tags_present/2" do
+    test "returns the subset of the given tags that exist for the repo" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "26.2-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "25.3-ubuntu-noble-20250101", ["arm64"])
 
-      assert Artifacts.docker_tags("hexpm/erlang-amd64") == [{"a", ["amd64"]}]
+      present =
+        Artifacts.docker_tags_present("hexpm/erlang-amd64", [
+          "27.0-ubuntu-noble-20250101",
+          "30.0-ubuntu-noble-20250101",
+          "25.3-ubuntu-noble-20250101"
+        ])
+
+      assert present == MapSet.new(["27.0-ubuntu-noble-20250101"])
     end
 
-    test "returns an empty list for an unknown repo" do
-      assert Artifacts.docker_tags("hexpm/erlang-amd64") == []
+    test "returns an empty set for no tags" do
+      assert Artifacts.docker_tags_present("hexpm/erlang-amd64", []) == MapSet.new()
+    end
+  end
+
+  describe "erlang_tags_for_os_versions/2" do
+    test "returns repo and tag for the requested repos and os_versions only" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-alpine-3.23.5", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "26.2-ubuntu-noble-20240101", ["amd64"])
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      tags =
+        Artifacts.erlang_tags_for_os_versions(
+          ["hexpm/erlang-amd64", "hexpm/erlang-arm64"],
+          ["noble-20250101", "3.23.5"]
+        )
+
+      assert Enum.sort(tags) == [
+               {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"},
+               {"hexpm/erlang-arm64", "27.0-alpine-3.23.5"}
+             ]
+    end
+  end
+
+  describe "manifest_mismatches/3" do
+    test "returns per-arch tags that have no manifest at all" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == [{"27.0-ubuntu-noble-20250101", ["amd64", "arm64"]}]
+    end
+
+    test "returns tags whose manifest lacks one of the built archs" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == [{"27.0-ubuntu-noble-20250101", ["amd64", "arm64"]}]
+    end
+
+    test "skips tags whose manifest covers every built arch" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == []
+    end
+
+    test "skips a manifest that has more archs than were built" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == []
+    end
+
+    test "ignores tags that only exist in the manifest repo" do
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == []
+    end
+
+    test "returns a single-arch tag without a manifest with just that arch" do
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      assert Artifacts.manifest_mismatches(
+               "hexpm/erlang",
+               "hexpm/erlang-amd64",
+               "hexpm/erlang-arm64"
+             ) == [{"27.0-ubuntu-noble-20250101", ["arm64"]}]
     end
   end
 

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -1,53 +1,18 @@
 defmodule Bob.Job.DockerCheckerTest do
   use Bob.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Bob.Job.DockerChecker
   alias Bob.Artifacts
   alias Bob.Artifacts.BaseImageTag
   alias Bob.Queue.Job
 
-  describe "erlang_tags/1" do
-    test "reads and parses per-arch erlang tags from docker_tags" do
-      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+  @builds_txt_url "https://s3.amazonaws.com/s3.hex.pm/builds/elixir/builds.txt"
 
-      assert DockerChecker.erlang_tags("amd64") ==
-               [{"27.0", "ubuntu", "noble-20250101", "amd64"}]
-    end
-  end
-
-  describe "elixir_tags/1" do
-    test "reads and parses per-arch elixir tags from docker_tags" do
-      Artifacts.add_docker_tag(
-        "hexpm/elixir-amd64",
-        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
-        ["amd64"]
-      )
-
-      assert DockerChecker.elixir_tags("amd64") ==
-               [{"1.18.0", "27.0", "ubuntu", "noble-20250101", "amd64"}]
-    end
-  end
-
-  describe "erlang_manifest_tags/0" do
-    test "reads manifest tags with their archs from docker_tags" do
-      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
-
-      assert DockerChecker.erlang_manifest_tags() ==
-               %{{"27.0", "ubuntu", "noble-20250101"} => ["amd64", "arm64"]}
-    end
-  end
-
-  describe "elixir_manifest_tags/0" do
-    test "reads manifest tags with their archs from docker_tags" do
-      Artifacts.add_docker_tag(
-        "hexpm/elixir",
-        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
-        ["amd64", "arm64"]
-      )
-
-      assert DockerChecker.elixir_manifest_tags() ==
-               %{{"1.18.0", "27.0", "ubuntu", "noble-20250101"} => ["amd64", "arm64"]}
-    end
+  setup do
+    Bob.FakeHttpClient.reset()
+    :ok
   end
 
   describe "builds/0" do
@@ -64,43 +29,106 @@ defmodule Bob.Job.DockerCheckerTest do
     end
   end
 
-  describe "diff_manifests/3" do
-    test "enqueues a manifest job when expected archs are missing" do
-      expected = %{{"27.0", "ubuntu", "noble-20250101"} => ["amd64", "arm64"]}
+  describe "expected_elixir_tags/0" do
+    test "crosses current-os-version erlang tags with compatible elixir builds" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      # An erlang tag on a base image that is no longer current contributes nothing.
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20240101", ["arm64"])
 
-      DockerChecker.diff_manifests("erlang", expected, %{})
+      Bob.FakeHttpClient.stub(
+        :get,
+        @builds_txt_url,
+        200,
+        "v1.18.0-otp-27 abc123\nv1.18.0-otp-26 def456\n"
+      )
+
+      assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
+               [{"1.18.0", "27.0", "ubuntu", "noble-20250101", "amd64"}]
+    end
+  end
+
+  describe "elixir/0" do
+    setup do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
+      :ok
+    end
+
+    test "enqueues builds for expected elixir tags missing from the mirror" do
+      DockerChecker.elixir()
+
+      assert [%Job{module_key: {Bob.Job.BuildDockerElixir, "amd64"}, args: args}] = Repo.all(Job)
+      assert args == ["1.18.0", "27.0", "ubuntu", "noble-20250101"]
+    end
+
+    test "does not enqueue elixir tags that are already built" do
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      DockerChecker.elixir()
+
+      assert Repo.all(Job) == []
+    end
+  end
+
+  describe "manifest/0" do
+    test "enqueues manifest jobs for per-arch tags missing from the manifest repo" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      DockerChecker.manifest()
+
+      jobs = Repo.all(Job) |> Enum.map(&{&1.module_key, &1.args}) |> Enum.sort()
+
+      assert jobs ==
+               Enum.sort([
+                 {Bob.Job.DockerManifest, ["erlang", {"27.0", "ubuntu", "noble-20250101"}]},
+                 {Bob.Job.DockerManifest,
+                  ["elixir", {"1.18.0", "27.0", "ubuntu", "noble-20250101"}]}
+               ])
+    end
+
+    test "does not enqueue when the manifest already covers the built archs" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
+
+      DockerChecker.manifest()
+
+      assert Repo.all(Job) == []
+    end
+
+    test "enqueues when the manifest lacks one of the built archs" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      DockerChecker.manifest()
 
       assert [%Job{module_key: Bob.Job.DockerManifest, args: args}] = Repo.all(Job)
       assert args == ["erlang", {"27.0", "ubuntu", "noble-20250101"}]
     end
 
-    test "does not enqueue when the manifest already has all archs" do
-      key = {"27.0", "ubuntu", "noble-20250101"}
-      expected = %{key => ["amd64", "arm64"]}
-      current = %{key => ["amd64", "arm64"]}
+    test "skips per-arch tags that cannot be parsed instead of crashing" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "latest", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
 
-      DockerChecker.diff_manifests("erlang", expected, current)
+      log = capture_log(fn -> DockerChecker.manifest() end)
 
-      assert Repo.all(Job) == []
-    end
-
-    test "enqueues when only some archs are present" do
-      key = {"27.0", "ubuntu", "noble-20250101"}
-      expected = %{key => ["amd64", "arm64"]}
-      current = %{key => ["amd64"]}
-
-      DockerChecker.diff_manifests("erlang", expected, current)
-
-      assert [%Job{module_key: Bob.Job.DockerManifest}] = Repo.all(Job)
-    end
-  end
-
-  describe "diff/2" do
-    test "returns expected entries that are not in current" do
-      expected = [{"a", 1}, {"b", 2}, {"c", 3}]
-      current = [{"b", 2}]
-
-      assert Enum.sort(DockerChecker.diff(expected, current)) == [{"a", 1}, {"c", 3}]
+      assert log =~ "latest"
+      assert [%Job{module_key: Bob.Job.DockerManifest, args: args}] = Repo.all(Job)
+      assert args == ["erlang", {"27.0", "ubuntu", "noble-20250101"}]
     end
   end
 end


### PR DESCRIPTION
DockerChecker previously pulled every tag of all six hexpm Docker repos out of the docker_tags mirror on each run - twelve full per-repo reads, about five million rows regex-parsed in the BEAM - which took ~15 minutes in production and held GB-scale working sets in memory.

Each pass now computes its small expected set and asks Postgres only about that: the erlang and elixir passes probe presence with tag = ANY(expected) on the unique (repo, tag) index, the elixir pass scopes its erlang read to current base-image os_versions via the search metadata, and the manifest pass became a single anti-join that returns only mismatched tags (normally none). On a production-scale snapshot the data path drops from ~41s to ~7s locally; in production the win is larger since ~190k rows transfer instead of ~4.9M.

A junk tag in a per-arch repo no longer crashes the whole run; the manifest pass now skips it with a log line. The GitHub refs fetch pages at per_page=100, cutting ~20 sequential requests to ~7.