### PR TITLE
Requeue interrupted jobs instead of leaving them stuck running

### DIFF
--- a/lib/bob/queue.ex
+++ b/lib/bob/queue.ex
@@ -133,6 +133,37 @@ defmodule Bob.Queue do
     :ok
   end
 
+  @doc """
+  Puts a running job back in the queue, e.g. when its node shuts down mid-run.
+
+  Unlike `failure/1` this records no backoff — the job was interrupted, not
+  broken. The row keeps its `inserted_at`, so it returns to the front of the
+  FIFO and is picked up as soon as a runner polls.
+  """
+  def requeue(id) do
+    now = DateTime.utc_now()
+
+    {_count, rows} =
+      Repo.update_all(
+        from(j in Job,
+          where: j.id == ^id and j.state == "running",
+          select: {j.module_key, j.args}
+        ),
+        set: [state: "queued", started_at: nil, updated_at: now]
+      )
+
+    case rows do
+      [{module_key, args}] ->
+        Logger.info("REQUEUED #{inspect(module_key)} #{inspect(args)}")
+        broadcast()
+
+      [] ->
+        :ok
+    end
+
+    :ok
+  end
+
   def queue_sizes() do
     Repo.all(
       from(j in Job,

--- a/lib/bob/queue/job.ex
+++ b/lib/bob/queue/job.ex
@@ -6,6 +6,7 @@ defmodule Bob.Queue.Job do
     field(:args, Bob.Queue.Term)
     field(:args_digest, :binary)
     field(:state, :string)
+    field(:requeues, :integer, default: 0)
     field(:inserted_at, :utc_datetime_usec)
     field(:updated_at, :utc_datetime_usec)
     field(:started_at, :utc_datetime_usec)

--- a/lib/bob/queue/maintenance.ex
+++ b/lib/bob/queue/maintenance.ex
@@ -1,8 +1,9 @@
 defmodule Bob.Queue.Maintenance do
   @moduledoc """
   Periodic queue maintenance, guarded by a Postgres advisory lock so exactly
-  one master instance does the work: times out stale running jobs, prunes
-  expired backoff rows, and prunes old job history.
+  one master instance does the work: requeues stale running jobs (failing them
+  once their requeues are exhausted), prunes expired backoff rows, and prunes
+  old job history.
   """
 
   use GenServer
@@ -14,6 +15,10 @@ defmodule Bob.Queue.Maintenance do
 
   @interval_seconds 60
   @job_timeout_seconds 3 * 60 * 60
+  # A job stuck in running this long means its node died hard (OOM, node loss),
+  # so the work itself is not suspect — requeue it. The cap stops a job that
+  # reliably kills its node or genuinely exceeds the timeout from looping.
+  @max_timeout_requeues 2
   @backoff_expiry_seconds 7 * 24 * 60 * 60
   @history_retention_seconds 90 * 24 * 60 * 60
   @advisory_lock_key 4_771_001
@@ -60,16 +65,26 @@ defmodule Bob.Queue.Maintenance do
     now = DateTime.utc_now()
     cutoff = DateTime.add(now, -@job_timeout_seconds, :second)
 
-    {count, _} =
+    stale =
+      from(j in Job,
+        where: j.state == "running" and not is_nil(j.started_at) and j.started_at < ^cutoff
+      )
+
+    {requeued, _} =
       Repo.update_all(
-        from(j in Job,
-          where: j.state == "running" and not is_nil(j.started_at) and j.started_at < ^cutoff
-        ),
+        from(j in stale, where: j.requeues < @max_timeout_requeues),
+        set: [state: "queued", started_at: nil, updated_at: now],
+        inc: [requeues: 1]
+      )
+
+    {failed, _} =
+      Repo.update_all(
+        from(j in stale, where: j.requeues >= @max_timeout_requeues),
         set: [state: "failed", finished_at: now, updated_at: now]
       )
 
-    if count > 0 do
-      Logger.info("SWEEP timed out #{count} running job(s)")
+    if requeued > 0 or failed > 0 do
+      Logger.info("SWEEP requeued #{requeued} and timed out #{failed} running job(s)")
     end
   end
 

--- a/lib/bob/remote_queue.ex
+++ b/lib/bob/remote_queue.ex
@@ -23,6 +23,14 @@ defmodule Bob.RemoteQueue do
     done_request(:failure, id)
   end
 
+  def requeue({:local, id}) do
+    Bob.Queue.requeue(id)
+  end
+
+  def requeue({:remote, id}) do
+    done_request(:requeue, id)
+  end
+
   def local_queue(max_weight, weights) do
     Application.get_env(:bob, :local_jobs)
     |> prioritize()

--- a/lib/bob/runner.ex
+++ b/lib/bob/runner.ex
@@ -1,5 +1,7 @@
 defmodule Bob.Runner do
-  use GenServer
+  # The shutdown timeout must leave terminate/2 room to requeue every in-flight
+  # job; agents do that over HTTP to the master.
+  use GenServer, shutdown: 15_000
   require Logger
 
   @local_timeout 1_000
@@ -13,6 +15,10 @@ defmodule Bob.Runner do
   # no Bob.Repo and only pull work from the master over HTTP, so they must never
   # touch the local queue. Dispatch every poll on the node's role.
   def init(state) do
+    # Trap exits so terminate/2 runs on shutdown and a crashing task does not
+    # take the runner (and its bookkeeping of the other running jobs) with it.
+    Process.flag(:trap_exit, true)
+
     if Application.get_env(:bob, :master?) do
       Process.send_after(self(), :local_timeout, 0)
     else
@@ -40,7 +46,7 @@ defmodule Bob.Runner do
   end
 
   def handle_info({ref, result}, state) when is_reference(ref) do
-    {key, args, job_id} = Map.fetch!(state.tasks, ref)
+    {key, args, job_id, _pid} = Map.fetch!(state.tasks, ref)
 
     case result do
       :ok ->
@@ -58,6 +64,27 @@ defmodule Bob.Runner do
   end
 
   def handle_info({:DOWN, _ref, :process, _pid, :normal}, state) do
+    {:noreply, state}
+  end
+
+  # run_task only rescues exceptions; a throw/exit kills the task without a
+  # result message, so the abnormal :DOWN is where that job gets accounted for.
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case Map.pop(state.tasks, ref) do
+      {nil, _tasks} ->
+        {:noreply, state}
+
+      {{key, args, job_id, _pid}, tasks} ->
+        if job_id, do: Bob.RemoteQueue.failure(job_id)
+        Logger.error("FAILED #{inspect(key)} #{inspect(args)} (#{inspect(reason)})")
+        state = start_any_jobs(%{state | tasks: tasks})
+        {:noreply, state}
+    end
+  end
+
+  # Tasks are linked and exits are trapped; the :DOWN clauses above do the
+  # bookkeeping for both normal and abnormal task ends.
+  def handle_info({:EXIT, _pid, _reason}, state) do
     {:noreply, state}
   end
 
@@ -108,8 +135,21 @@ defmodule Bob.Runner do
     end)
   end
 
+  def terminate(_reason, state) do
+    Enum.each(state.tasks, fn {_ref, {key, args, job_id, pid}} ->
+      # Kill the task before requeueing so a straggler completion report can't
+      # finish a row that another node may have re-claimed by then.
+      Task.Supervisor.terminate_child(Bob.Tasks, pid)
+
+      if job_id do
+        Logger.info("REQUEUING ON SHUTDOWN #{inspect(key)} #{inspect(args)}")
+        Bob.RemoteQueue.requeue(job_id)
+      end
+    end)
+  end
+
   defp current_weight(state) do
-    Enum.reduce(state.tasks, %{}, fn {_ref, {module, _args, _id}}, weights ->
+    Enum.reduce(state.tasks, %{}, fn {_ref, {module, _args, _id, _pid}}, weights ->
       concurrency_key = apply_task(module, :concurrency, [])
       weight = apply_task(module, :weight, [])
       Map.update(weights, concurrency_key, weight, &(&1 + weight))
@@ -119,7 +159,7 @@ defmodule Bob.Runner do
   defp start_job(id, key, args, state) do
     Logger.info("STARTING #{inspect(key)} #{inspect(args)}")
     task = Task.Supervisor.async(Bob.Tasks, fn -> run_task(key, args) end)
-    put_in(state.tasks[task.ref], {key, args, id})
+    put_in(state.tasks[task.ref], {key, args, id, task.pid})
   end
 
   defp new_state do

--- a/lib/bob_web/controllers/queue_controller.ex
+++ b/lib/bob_web/controllers/queue_controller.ex
@@ -22,6 +22,11 @@ defmodule BobWeb.QueueController do
     send_resp(conn, 204, "")
   end
 
+  def requeue(conn, params) do
+    Bob.Queue.requeue(params.id)
+    send_resp(conn, 204, "")
+  end
+
   def add(conn, params) do
     Bob.Queue.add(params.module, params.args)
     send_resp(conn, 204, "")

--- a/lib/bob_web/router.ex
+++ b/lib/bob_web/router.ex
@@ -14,6 +14,7 @@ defmodule BobWeb.Router do
     post("/queue/start", QueueController, :start)
     post("/queue/success", QueueController, :success)
     post("/queue/failure", QueueController, :failure)
+    post("/queue/requeue", QueueController, :requeue)
     post("/queue/add", QueueController, :add)
     post("/artifacts/add", ArtifactController, :add)
     post("/docker/add", ArtifactController, :add_docker)

--- a/priv/repo/migrations/20260611120000_add_requeues_to_jobs.exs
+++ b/priv/repo/migrations/20260611120000_add_requeues_to_jobs.exs
@@ -1,0 +1,9 @@
+defmodule Bob.Repo.Migrations.AddRequeuesToJobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:jobs) do
+      add(:requeues, :integer, default: 0, null: false)
+    end
+  end
+end

--- a/test/bob/queue/maintenance_test.exs
+++ b/test/bob/queue/maintenance_test.exs
@@ -38,13 +38,27 @@ defmodule Bob.Queue.MaintenanceTest do
 
   defp ago(seconds), do: DateTime.add(DateTime.utc_now(), -seconds, :second)
 
-  test "sweeps stale running jobs to failed without recording backoff" do
+  test "requeues stale running jobs without recording backoff" do
     old = ago(4 * @hour)
     insert_job(state: "running", inserted_at: old, started_at: old)
 
     Maintenance.run()
 
-    assert [%Job{state: "failed", finished_at: finished}] = Repo.all(Job)
+    assert [%Job{state: "queued", started_at: nil, requeues: 1, inserted_at: inserted}] =
+             Repo.all(Job)
+
+    # inserted_at is kept so the requeued job stays at the front of the queue.
+    assert DateTime.compare(inserted, old) == :eq
+    assert Repo.all(Failure) == []
+  end
+
+  test "fails a stale running job once its requeues are exhausted" do
+    old = ago(4 * @hour)
+    insert_job(state: "running", inserted_at: old, started_at: old, requeues: 2)
+
+    Maintenance.run()
+
+    assert [%Job{state: "failed", finished_at: finished, requeues: 2}] = Repo.all(Job)
     assert finished != nil
     assert Repo.all(Failure) == []
   end

--- a/test/bob/queue_test.exs
+++ b/test/bob/queue_test.exs
@@ -159,6 +159,44 @@ defmodule Bob.QueueTest do
     assert size(TestJob) == 1
   end
 
+  test "requeue puts a running job back at the front of the queue" do
+    Queue.add(TestJob, [:a])
+    Queue.add(TestJob, [:b])
+    {:ok, {id, [:a]}} = Queue.start(TestJob)
+
+    assert Queue.requeue(id) == :ok
+
+    job = Repo.get!(Bob.Queue.Job, id)
+    assert job.state == "queued"
+    assert job.started_at == nil
+
+    # The old inserted_at is kept, so the requeued job is picked before [:b].
+    assert {:ok, {^id, [:a]}} = Queue.start(TestJob)
+  end
+
+  test "requeue does not record a failure" do
+    Queue.add(TestJob, [:a])
+    {:ok, {id, [:a]}} = Queue.start(TestJob)
+
+    Queue.requeue(id)
+
+    assert Repo.all(Bob.Queue.Failure) == []
+  end
+
+  test "requeue on a job that is not running is a no-op" do
+    Queue.add(TestJob, [:a])
+    queued = Repo.one(Bob.Queue.Job)
+    assert Queue.requeue(queued.id) == :ok
+    assert Repo.get!(Bob.Queue.Job, queued.id).state == "queued"
+
+    {:ok, {id, [:a]}} = Queue.start(TestJob)
+    Queue.success(id)
+    assert Queue.requeue(id) == :ok
+    assert Repo.get!(Bob.Queue.Job, id).state == "done"
+
+    assert Queue.requeue(-1) == :ok
+  end
+
   test "success on an unknown id is a no-op" do
     assert Queue.success(-1) == :ok
   end
@@ -220,6 +258,15 @@ defmodule Bob.QueueTest do
       Bob.Queue.add(Bob.Job.OTPChecker, [:a])
       assert_receive :jobs_changed
       {:ok, _} = Bob.Queue.start(Bob.Job.OTPChecker)
+      assert_receive :jobs_changed
+    end
+
+    test "requeue broadcasts :jobs_changed" do
+      Bob.Queue.add(Bob.Job.OTPChecker, [:a])
+      assert_receive :jobs_changed
+      {:ok, {id, _}} = Bob.Queue.start(Bob.Job.OTPChecker)
+      assert_receive :jobs_changed
+      Bob.Queue.requeue(id)
       assert_receive :jobs_changed
     end
 

--- a/test/bob/runner_test.exs
+++ b/test/bob/runner_test.exs
@@ -10,6 +10,13 @@ defmodule Bob.RunnerTest do
     def concurrency(), do: :shared
   end
 
+  defmodule BlockingJob do
+    def run(), do: Process.sleep(:infinity)
+    def priority(), do: 1
+    def weight(), do: 1
+    def concurrency(), do: :shared
+  end
+
   setup do
     on_exit(fn ->
       case Process.whereis(Bob.Runner) do
@@ -42,6 +49,57 @@ defmodule Bob.RunnerTest do
       :sys.get_state(runner)
 
       assert Bob.Queue.start(QuietJob) == :error
+    end
+
+    test "shutdown requeues in-flight jobs" do
+      # The runner exits with :shutdown, which would propagate over the
+      # start_link link and kill the test.
+      Process.flag(:trap_exit, true)
+
+      previous = Application.get_env(:bob, :local_jobs)
+      Application.put_env(:bob, :local_jobs, [BlockingJob])
+      on_exit(fn -> Application.put_env(:bob, :local_jobs, previous) end)
+
+      Bob.Queue.add(BlockingJob, [])
+
+      {:ok, runner} = Bob.Runner.start_link([])
+      send(runner, :local_timeout)
+      :sys.get_state(runner)
+
+      # The job is claimed and its task is blocked inside run/0.
+      assert Bob.Queue.start(BlockingJob) == :error
+      [%{state: "running"} = job] = Bob.Queue.running()
+
+      :ok = GenServer.stop(runner, :shutdown)
+
+      assert Bob.Repo.get!(Bob.Queue.Job, job.id).state == "queued"
+    end
+
+    test "shutdown kills the in-flight task before requeueing" do
+      task = Task.Supervisor.async_nolink(Bob.Tasks, fn -> Process.sleep(:infinity) end)
+
+      Bob.Queue.add(QuietJob, [:terminate_test])
+      {:ok, {id, [:terminate_test]}} = Bob.Queue.start(QuietJob)
+
+      state = %{tasks: %{task.ref => {QuietJob, [:terminate_test], {:local, id}, task.pid}}}
+      Bob.Runner.terminate(:shutdown, state)
+
+      refute Process.alive?(task.pid)
+      assert Bob.Repo.get!(Bob.Queue.Job, id).state == "queued"
+    end
+
+    test "an abnormal task exit marks the job failed" do
+      Bob.Queue.add(QuietJob, [:down_test])
+      {:ok, {id, [:down_test]}} = Bob.Queue.start(QuietJob)
+
+      ref = make_ref()
+      state = %{tasks: %{ref => {QuietJob, [:down_test], {:local, id}, self()}}}
+
+      {:noreply, new_state} =
+        Bob.Runner.handle_info({:DOWN, ref, :process, self(), :killed}, state)
+
+      assert new_state.tasks == %{}
+      assert Bob.Repo.get!(Bob.Queue.Job, id).state == "failed"
     end
   end
 

--- a/test/bob_web/controllers/api_test.exs
+++ b/test/bob_web/controllers/api_test.exs
@@ -118,6 +118,22 @@ defmodule BobWeb.ApiTest do
     assert [{Bob.Job.OTPChecker, [:tags]}] = Bob.Queue.queued()
   end
 
+  test "POST /api/queue/requeue puts a running job back in the queue", %{conn: conn} do
+    Bob.Queue.add(Bob.Job.OTPChecker, [:tags])
+    {:ok, {id, [:tags]}} = Bob.Queue.start(Bob.Job.OTPChecker)
+
+    body = Bob.Plug.ErlangFormat.encode_to_iodata!(%{id: id})
+
+    conn =
+      conn
+      |> put_req_header("content-type", "application/vnd.bob+erlang")
+      |> put_req_header("authorization", "secret")
+      |> post(~p"/api/queue/requeue", body)
+
+    assert conn.status == 204
+    assert [{Bob.Job.OTPChecker, [:tags]}] = Bob.Queue.queued()
+  end
+
   test "GET /status still returns 200 at the root", %{conn: conn} do
     conn = get(conn, "/status")
     assert conn.status == 200


### PR DESCRIPTION
On shutdown (SIGTERM from deploys) the runner now traps exits and its terminate kills in-flight tasks and puts their jobs back at the front of the queue, instead of leaving the rows in running until the maintenance sweep fails them three hours later. Agents report the requeue to the master over a new /api/queue/requeue endpoint.

The maintenance sweep likewise requeues stale running jobs - a job stuck for three hours means its node died hard, not that the work is suspect - capped at two requeues before it is marked failed. Requeueing records no backoff and keeps inserted_at, so interrupted jobs resume promptly.

A crashing task (throw/exit) no longer takes the runner down with it; the abnormal DOWN now marks that job failed and the runner keeps its bookkeeping for the other running jobs.