### PR TITLE
Fix job pill and duration column layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -612,6 +612,7 @@ pre,
   align-items: center;
   gap: 7px;
   height: 32px;
+  white-space: nowrap;
   padding: 0 12px;
   border: 1px solid var(--color-grey-200);
   border-radius: 999px;
@@ -734,6 +735,11 @@ pre,
 .col-time {
   width: 190px;
   min-width: 190px;
+  white-space: nowrap;
+}
+
+.col-dur {
+  width: 1%;
   white-space: nowrap;
 }
 

--- a/lib/bob_web/live/jobs_live.ex
+++ b/lib/bob_web/live/jobs_live.ex
@@ -162,6 +162,10 @@ defmodule BobWeb.JobsLive do
   defp to_naive(%NaiveDateTime{} = datetime), do: datetime
 
   defp module_name(module_key), do: inspect(module_key)
+
+  defp module_label({module, key}), do: "#{inspect(module)} #{key}"
+  defp module_label(module), do: inspect(module)
+
   defp args_text(args), do: inspect(args)
 
   defp housekeeping?(module_key) do
@@ -204,7 +208,7 @@ defmodule BobWeb.JobsLive do
           phx-value-module={module_name(mod)}
         >
           <.cat_glyph cat={job_cat(mod)} size={13} />
-          <%= module_name(mod) %>
+          <%= module_label(mod) %>
           <span :if={@queued_counts[mod]} class="chip__n"><%= @queued_counts[mod] %></span>
         </button>
       </div>
@@ -226,7 +230,7 @@ defmodule BobWeb.JobsLive do
             </div>
           </:col>
           <:col :let={j} label="Module">
-            <.module_cell cat={job_cat(j.module_key)} module={module_name(j.module_key)} />
+            <.module_cell cat={job_cat(j.module_key)} module={module_label(j.module_key)} />
           </:col>
           <:col :let={j} label="Args" class="col-args">
             <code class="c-args"><%= args_text(j.args) %></code>
@@ -234,7 +238,7 @@ defmodule BobWeb.JobsLive do
           <:col :let={j} label="Started" class="col-time">
             <span class="c-time"><%= fmt(j.started_at) %></span>
           </:col>
-          <:col :let={j} label="Elapsed" class="col-time">
+          <:col :let={j} label="Elapsed" class="col-dur">
             <span class="c-elapsed"><%= fmt_duration(elapsed(j.started_at, @now)) %></span>
           </:col>
         </.table>
@@ -246,7 +250,7 @@ defmodule BobWeb.JobsLive do
 
         <.table :if={!@loading and @queued != []} rows={@queued}>
           <:col :let={j} label="Module">
-            <.module_cell cat={job_cat(j.module_key)} module={module_name(j.module_key)} />
+            <.module_cell cat={job_cat(j.module_key)} module={module_label(j.module_key)} />
           </:col>
           <:col :let={j} label="Args" class="col-args">
             <code class="c-args"><%= args_text(j.args) %></code>
@@ -275,12 +279,12 @@ defmodule BobWeb.JobsLive do
             <.state_badge state={j.state} />
           </:col>
           <:col :let={j} label="Module">
-            <.module_cell cat={job_cat(j.module_key)} module={module_name(j.module_key)} />
+            <.module_cell cat={job_cat(j.module_key)} module={module_label(j.module_key)} />
           </:col>
           <:col :let={j} label="Args" class="col-args">
             <code class="c-args"><%= args_text(j.args) %></code>
           </:col>
-          <:col :let={j} label="Duration" class="col-time">
+          <:col :let={j} label="Duration" class="col-dur">
             <span class="c-dur"><%= fmt_duration(duration(j)) %></span>
           </:col>
           <:col :let={j} label="Finished" class="col-time">

--- a/test/bob_web/live/jobs_live_test.exs
+++ b/test/bob_web/live/jobs_live_test.exs
@@ -68,6 +68,15 @@ defmodule BobWeb.JobsLiveTest do
     assert html =~ ":docker_done"
   end
 
+  test "renders tuple module keys without inspect syntax", %{conn: conn} do
+    Bob.Queue.add({Bob.Job.BuildDockerElixir, "amd64"}, [:tuple_label])
+
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    assert html =~ "Bob.Job.BuildDockerElixir amd64"
+    assert html =~ ~s(phx-value-module="{Bob.Job.BuildDockerElixir, &quot;amd64&quot;}")
+  end
+
   test "orders work chips before checker and maintenance chips", %{conn: conn} do
     Bob.Queue.add(Bob.Job.DockerChecker, [:a])
     Bob.Queue.add(Bob.Job.OTPChecker, [:b])


### PR DESCRIPTION
Tuple module keys like `{Bob.Job.BuildDockerElixir, "amd64"}` rendered as raw inspect syntax in the jobs page filter chips and wrapped to two lines inside the fixed-height pills, overflowing onto the card below. They now render as `Bob.Job.BuildDockerElixir amd64` in the chips and table module cells, and chip labels no longer wrap (the filter row wraps whole pills instead). The filter identity (`phx-value-module`) keeps the inspect form, so toggling is unchanged.

The Elapsed and Duration columns also shared the 190px `col-time` width meant for full timestamps; they now use a shrink-to-fit column.