### PR TITLE
Diff Docker manifest archs with a full join instead of an aggregate

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -431,18 +431,23 @@ defmodule Bob.Artifacts do
   as is a manifest carrying more archs than were built.
   """
   def manifest_mismatches(manifest_repo, amd64_repo, arm64_repo) do
-    # The ::text[] cast is required: archs is varchar[] and array containment
-    # does not unify varchar[] with the aggregated text[].
+    # Tags are unique per repo, so the built-arch sets come from a full join of
+    # two index-only scans on (repo, tag) — no sort or aggregate over the
+    # repos' full histories, which also keeps the plan fast regardless of
+    # work_mem (a GROUP BY formulation degrades ~4x once its sort fits in
+    # memory). The ::text[] cast is required: archs is varchar[] and array
+    # containment does not unify varchar[] with text[].
     %{rows: rows} =
       Repo.query!(
         """
         SELECT p.tag, p.archs
         FROM (
-          SELECT tag,
-                 array_agg(DISTINCT CASE WHEN repo = $2 THEN 'amd64' ELSE 'arm64' END) AS archs
-          FROM docker_tags
-          WHERE repo IN ($2, $3)
-          GROUP BY tag
+          SELECT COALESCE(a.tag, b.tag) AS tag,
+                 CASE WHEN b.tag IS NULL THEN ARRAY['amd64']
+                      WHEN a.tag IS NULL THEN ARRAY['arm64']
+                      ELSE ARRAY['amd64', 'arm64'] END AS archs
+          FROM (SELECT tag FROM docker_tags WHERE repo = $2) a
+          FULL JOIN (SELECT tag FROM docker_tags WHERE repo = $3) b ON a.tag = b.tag
         ) AS p
         LEFT JOIN docker_tags m ON m.repo = $1 AND m.tag = p.tag
         WHERE m.id IS NULL OR NOT (m.archs::text[] @> p.archs)


### PR DESCRIPTION
manifest_mismatches/3 aggregated both per-arch repos' full tag histories (GROUP BY tag + array_agg over ~1.9M rows for elixir), forcing a sort of the whole set on every run. With work_mem below the sort's ~218MB footprint that spills to a fast external merge, but past it the planner switches to a single in-memory quicksort doing full locale-collated comparisons, which is ~4x slower — the regime production runs in, at ~20s per elixir call every 15 minutes.

Tags are unique per (repo, tag), so the built-arch set is simply which of the two per-arch repos contain the tag. A full join of two index-only scans computes the same result with no sort or aggregate and also parallelizes: 3.4s to 0.57s for elixir and 264ms to 9.7ms for erlang on a production-sized snapshot, flat across work_mem settings, with the generic prepared-statement plan holding at ~0.6s.

Verified against the old query on synthesized mismatches of every class (missing manifest, manifest lacking a built arch, single-arch tag with and without coverage, manifest-only tag): identical rows in both directions.