### PR TITLE
Latest patch builds and requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,22 @@ For lists of builds see:
 
 ## Docker images
 
-Docker images for Bob's Elixir and Erlang builds are built periodically. Bob checks for new Elixir and Erlang releases every 15 minutes and builds images for any new versions it discovers. The list of operating system distributions we base the images on can be found here: https://github.com/hexpm/bob/blob/main/lib/bob/job/docker_checker.ex#L5.
+Docker images for Bob's Elixir and Erlang builds are built periodically. Bob checks for new Elixir and Erlang releases every 15 minutes and builds images for any new versions it discovers. The list of operating system distributions we base the images on is defined by `builds/0` in https://github.com/hexpm/bob/blob/main/lib/bob/job/docker_checker.ex.
+
+Bob automatically builds the latest patch release of every version family: the newest release per Erlang `major.minor` line (for example only `26.2.5.21` out of the `26.2.x` line) and the newest Elixir patch release per minor version, for every compatible OTP major. Older patch versions are not built automatically but can be requested manually, see below.
 
 Tagged images are never changed, that means `hexpm/erlang@22.0-alpine-3.11.2` will always target the tag `OTP-22.0` and won't update when `OTP-22.0.1` is released.
 
-Erlang builds are found at https://hub.docker.com/r/hexpm/erlang, they use the versioning scheme `${OTP_VER}-${OS_NAME}-${OS_VER}` for tags. Builds for all releases since OTP 17 are provided.
+Erlang builds are found at https://hub.docker.com/r/hexpm/erlang, they use the versioning scheme `${OTP_VER}-${OS_NAME}-${OS_VER}` for tags.
 
-Elixir builds are found at https://hub.docker.com/r/hexpm/elixir, they use the versioning scheme `${ELIXIR_VER}-erlang-${OTP_VER}-${OS_NAME}-${OS_VER}`. Builds for all major releases since Elixir 1.0.0 are provided. Images are built for all pairs of compatible Elixir and OTP versions.
+Elixir builds are found at https://hub.docker.com/r/hexpm/elixir, they use the versioning scheme `${ELIXIR_VER}-erlang-${OTP_VER}-${OS_NAME}-${OS_VER}`.
 
 Builds are provided for the following OS and architectures using the docker `OS/ARCH` scheme:
 
 * `linux/amd64`
 * `linux/arm64/v8`
+
+All provided images and tags can be searched at https://bob.hex.pm/docker.
 
 ### Examples of image names
 
@@ -56,3 +60,9 @@ Builds are provided for the following OS and architectures using the docker `OS/
  * `hexpm/erlang:22.2-ubuntu-bionic-20200219`
  * `hexpm/elixir:1.10.2-erlang-22.2.8-alpine-3.11.3`
  * `hexpm/elixir:1.10.0-erlang-22.2-ubuntu-bionic-20200219`
+
+### Requesting builds
+
+If you need a specific patch version that is not built automatically, request it at https://bob.hex.pm/request. Sign in with your hex.pm account, then pick the image kind (Erlang or Elixir), the OS and base image version, and the exact Erlang (and Elixir) version. The image is built for both architectures, including the multi-arch manifest; when an Elixir image needs an Erlang base image that does not exist yet, the base is built first and the Elixir image follows automatically.
+
+Requested builds are limited to ten image builds per user per hour. Build progress can be followed on the jobs dashboard at https://bob.hex.pm.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -287,6 +287,12 @@ pre,
   color: var(--color-grey-400);
 }
 
+.nav-user {
+  color: var(--color-grey-300);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
 .bob-main {
   flex: 1;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -126,14 +126,6 @@ pre,
   letter-spacing: 0;
 }
 
-.bob-brand__tag {
-  color: var(--color-grey-400);
-  font-size: 12px;
-  font-weight: 500;
-  padding-left: 11px;
-  border-left: 1px solid var(--color-grey-700);
-}
-
 .bob-nav__tabs {
   display: flex;
   align-items: center;
@@ -1091,7 +1083,6 @@ pre,
 }
 
 @media (max-width: 820px) {
-  .bob-brand__tag,
   .nav-ext {
     display: none;
   }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -72,13 +72,13 @@ pre,
 }
 
 .flash {
-  margin: 10px auto 0;
-  max-width: 1240px;
+  margin: 0 0 18px;
   border-radius: 8px;
   background: var(--color-grey-800);
   color: #fff;
-  padding: 8px 12px;
+  padding: 11px 14px;
   font-size: 13px;
+  line-height: 1.35;
 }
 
 .bob {
@@ -297,11 +297,6 @@ pre,
   padding: 14px 20px 0;
   font-size: 13.5px;
   color: var(--color-grey-600);
-}
-
-.req-heading {
-  padding: 14px 20px 0;
-  font-size: 14px;
 }
 
 .bob-main {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -293,6 +293,17 @@ pre,
   font-size: 12.5px;
 }
 
+.req-intro {
+  padding: 14px 20px 0;
+  font-size: 13.5px;
+  color: var(--color-grey-600);
+}
+
+.req-heading {
+  padding: 14px 20px 0;
+  font-size: 14px;
+}
+
 .bob-main {
   flex: 1;
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,8 @@ config :bob,
   master?: true,
   parallel_jobs: 1,
   local_jobs: [],
-  remote_jobs: []
+  remote_jobs: [],
+  hexpm_impl: Bob.Hexpm.Impl
 
 config :mime, :types, %{
   "application/vnd.bob+erlang" => ["erlang"]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,10 @@ import Config
 
 config :bob,
   master_schedule: [],
-  agent_schedule: []
+  agent_schedule: [],
+  hexpm_url: "http://localhost:4000",
+  oauth_client_id: "b0b00000-0000-4000-8000-000000000b0b",
+  oauth_client_secret: "dev_secret_for_testing"
 
 config :bob, Bob.Repo,
   username: "postgres",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,7 +16,10 @@ if config_env() == :prod do
     master?: System.fetch_env!("BOB_WHO") == "master",
     parallel_jobs: String.to_integer(System.fetch_env!("BOB_PARALLEL_JOBS")),
     local_jobs: jobs_fun.("BOB_LOCAL_JOBS"),
-    remote_jobs: jobs_fun.("BOB_REMOTE_JOBS")
+    remote_jobs: jobs_fun.("BOB_REMOTE_JOBS"),
+    hexpm_url: System.get_env("BOB_HEXPM_URL", "https://hex.pm"),
+    oauth_client_id: System.fetch_env!("BOB_OAUTH_CLIENT_ID"),
+    oauth_client_secret: System.fetch_env!("BOB_OAUTH_CLIENT_SECRET")
 
   config :ex_aws,
     access_key_id: System.fetch_env!("BOB_S3_ACCESS_KEY"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,7 +3,11 @@ import Config
 config :bob,
   master_schedule: [],
   agent_schedule: [],
-  github: Bob.FakeGitHub
+  github: Bob.FakeGitHub,
+  hexpm_impl: Bob.FakeHexpm,
+  hexpm_url: "http://localhost:4000",
+  oauth_client_id: "b0b00000-0000-4000-8000-000000000b0b",
+  oauth_client_secret: "test_secret"
 
 config :ex_aws,
   access_key_id: "test",

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,8 @@ import Config
 
 config :bob,
   master_schedule: [],
-  agent_schedule: []
+  agent_schedule: [],
+  github: Bob.FakeGitHub
 
 config :ex_aws,
   access_key_id: "test",

--- a/lib/bob/application.ex
+++ b/lib/bob/application.ex
@@ -17,6 +17,7 @@ defmodule Bob.Application do
           {Finch, name: Bob.Finch},
           {Task.Supervisor, [name: Bob.Tasks]},
           {Phoenix.PubSub, name: Bob.PubSub},
+          Bob.Cache,
           Bob.DockerHub.RateLimiter,
           Bob.DockerHub.Auth,
           runner_spec(),

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -408,6 +408,19 @@ defmodule Bob.Artifacts do
   end
 
   @doc """
+  The architectures a single tag covers, or `nil` if the tag is absent. Used to
+  tell whether a manifest tag already spans every architecture.
+  """
+  def docker_tag_archs(repo, tag) do
+    Repo.one(
+      from(d in DockerTag,
+        where: d.repo == ^repo and d.tag == ^tag,
+        select: d.archs
+      )
+    )
+  end
+
+  @doc """
   `{repo, tag}` for every tag of `repos` whose search metadata carries one of
   `os_versions`. Scopes the checker's erlang reads to current base images —
   a fraction of the full history.

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -508,7 +508,11 @@ defmodule Bob.Artifacts do
         select: {b.repo, b.tag}
       )
     )
-    |> MapSet.new(fn {"library/" <> os, tag} -> {os, tag} end)
+    |> Enum.flat_map(fn
+      {"library/" <> os, tag} -> [{os, tag}]
+      _other -> []
+    end)
+    |> MapSet.new()
   end
 
   def upsert(attrs) do

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -484,16 +484,31 @@ defmodule Bob.Artifacts do
 
   def replace_base_image_tags(repo, tags) do
     now = DateTime.utc_now()
+    tags = Enum.uniq(tags)
+    rows = Enum.map(tags, &%{repo: repo, tag: &1, inserted_at: now, updated_at: now})
 
-    rows =
-      tags |> Enum.uniq() |> Enum.map(&%{repo: repo, tag: &1, inserted_at: now, updated_at: now})
-
+    # Prune vanished tags but keep existing rows untouched, so inserted_at marks
+    # when a base image first appeared rather than the last reconcile.
     Repo.transaction(fn ->
-      Repo.delete_all(from(b in BaseImageTag, where: b.repo == ^repo))
-      Repo.insert_all(BaseImageTag, rows)
+      Repo.delete_all(from(b in BaseImageTag, where: b.repo == ^repo and b.tag not in ^tags))
+      Repo.insert_all(BaseImageTag, rows, on_conflict: :nothing, conflict_target: [:repo, :tag])
     end)
 
     :ok
+  end
+
+  @doc """
+  `{os, tag}` for every base image first seen on or after `cutoff`. A recent
+  base image is one of the components that makes a build worth triggering.
+  """
+  def recent_base_image_versions(cutoff) do
+    Repo.all(
+      from(b in BaseImageTag,
+        where: b.inserted_at >= ^cutoff,
+        select: {b.repo, b.tag}
+      )
+    )
+    |> MapSet.new(fn {"library/" <> os, tag} -> {os, tag} end)
   end
 
   def upsert(attrs) do

--- a/lib/bob/build_requests.ex
+++ b/lib/bob/build_requests.ex
@@ -27,18 +27,40 @@ defmodule Bob.BuildRequests do
   defp submit_jobs(request, attrs, jobs) do
     builds_count = builds_count(request.kind, jobs)
 
-    if over_limit?(request.username, builds_count) do
-      {:error, :rate_limited}
-    else
-      {:ok, request} = create(Map.put(attrs, :builds_count, builds_count))
-      Bob.Queue.add_many(jobs)
+    # Serialize a user's concurrent submits (e.g. two tabs) with a per-user
+    # advisory lock so the limit check and insert can't interleave and both
+    # slip past the cap.
+    result =
+      Repo.transaction(fn ->
+        lock_user(request.username)
 
-      Logger.info(
-        "BUILD REQUEST by #{request.username}: #{request.kind} #{request_target(request)}"
-      )
+        if over_limit?(request.username, builds_count) do
+          Repo.rollback(:rate_limited)
+        else
+          {:ok, created} = create(Map.put(attrs, :builds_count, builds_count))
+          created
+        end
+      end)
 
-      {:ok, request}
+    case result do
+      {:ok, created} ->
+        # Enqueue outside the lock; if it fails the request stays pending and
+        # the checker's reconciliation enqueues the jobs on its next cycle.
+        Bob.Queue.add_many(jobs)
+
+        Logger.info(
+          "BUILD REQUEST by #{created.username}: #{created.kind} #{request_target(created)}"
+        )
+
+        {:ok, created}
+
+      {:error, :rate_limited} ->
+        {:error, :rate_limited}
     end
+  end
+
+  defp lock_user(username) do
+    Repo.query!("SELECT pg_advisory_xact_lock(hashtext($1))", [username])
   end
 
   defp validate_combo(%{kind: "erlang"} = request) do

--- a/lib/bob/build_requests.ex
+++ b/lib/bob/build_requests.ex
@@ -66,14 +66,18 @@ defmodule Bob.BuildRequests do
     end
   end
 
-  # An erlang job under an elixir request implies a follow-up elixir build on
-  # the same arch, so it counts as two builds against the hourly limit.
-  defp builds_count("erlang", jobs), do: length(jobs)
+  # Only image builds count against the hourly limit; manifest assembly is
+  # cheap. An erlang job under an elixir request implies a follow-up elixir
+  # build on the same arch, so it counts as two.
+  defp builds_count("erlang", jobs) do
+    Enum.count(jobs, &match?({{Bob.Job.BuildDockerErlang, _arch}, _args}, &1))
+  end
 
   defp builds_count("elixir", jobs) do
     Enum.reduce(jobs, 0, fn
       {{Bob.Job.BuildDockerErlang, _arch}, _args}, acc -> acc + 2
       {{Bob.Job.BuildDockerElixir, _arch}, _args}, acc -> acc + 1
+      _other, acc -> acc
     end)
   end
 

--- a/lib/bob/build_requests.ex
+++ b/lib/bob/build_requests.ex
@@ -121,14 +121,35 @@ defmodule Bob.BuildRequests do
     )
   end
 
-  def recent_for_user(username, limit \\ 10) do
+  def recent(limit, offset) do
     Repo.all(
       from(request in BuildRequest,
-        where: request.username == ^username,
         order_by: [desc: request.inserted_at],
-        limit: ^limit
+        limit: ^limit,
+        offset: ^offset
       )
     )
+  end
+
+  def count() do
+    Repo.aggregate(BuildRequest, :count)
+  end
+
+  @doc """
+  Deletes finished requests older than `older_than_seconds`. Pending requests
+  are left alone; the checker reconciliation expires or completes them first.
+  """
+  def prune(older_than_seconds) do
+    cutoff = DateTime.add(DateTime.utc_now(), -older_than_seconds, :second)
+
+    {count, _} =
+      Repo.delete_all(
+        from(request in BuildRequest,
+          where: request.state in ["completed", "expired"] and request.inserted_at < ^cutoff
+        )
+      )
+
+    count
   end
 
   defp pending_query() do

--- a/lib/bob/build_requests.ex
+++ b/lib/bob/build_requests.ex
@@ -1,0 +1,136 @@
+defmodule Bob.BuildRequests do
+  import Ecto.Query
+
+  require Logger
+
+  alias Bob.BuildRequests.BuildRequest
+  alias Bob.Repo
+
+  @hourly_build_limit 10
+
+  def hourly_build_limit(), do: @hourly_build_limit
+
+  def submit(attrs) do
+    request = struct!(BuildRequest, attrs)
+
+    with :ok <- validate_combo(request) do
+      case Bob.Job.DockerChecker.request_jobs(request) do
+        [] ->
+          {:ok, :already_built}
+
+        jobs ->
+          submit_jobs(request, attrs, jobs)
+      end
+    end
+  end
+
+  defp submit_jobs(request, attrs, jobs) do
+    builds_count = builds_count(request.kind, jobs)
+
+    if over_limit?(request.username, builds_count) do
+      {:error, :rate_limited}
+    else
+      {:ok, request} = create(Map.put(attrs, :builds_count, builds_count))
+      Bob.Queue.add_many(jobs)
+
+      Logger.info(
+        "BUILD REQUEST by #{request.username}: #{request.kind} #{request_target(request)}"
+      )
+
+      {:ok, request}
+    end
+  end
+
+  defp validate_combo(%{kind: "erlang"} = request) do
+    if Bob.Job.DockerChecker.valid_erlang_build?(request.erlang, request.os, request.os_version) do
+      :ok
+    else
+      {:error, :invalid_combo}
+    end
+  end
+
+  defp validate_combo(%{kind: "elixir"} = request) do
+    otp_major = request.erlang |> String.split(".") |> hd()
+
+    if request.elixir != nil and
+         Bob.Job.DockerChecker.valid_elixir_build?(
+           request.elixir,
+           otp_major,
+           request.erlang,
+           request.os,
+           request.os_version
+         ) do
+      :ok
+    else
+      {:error, :invalid_combo}
+    end
+  end
+
+  # An erlang job under an elixir request implies a follow-up elixir build on
+  # the same arch, so it counts as two builds against the hourly limit.
+  defp builds_count("erlang", jobs), do: length(jobs)
+
+  defp builds_count("elixir", jobs) do
+    Enum.reduce(jobs, 0, fn
+      {{Bob.Job.BuildDockerErlang, _arch}, _args}, acc -> acc + 2
+      {{Bob.Job.BuildDockerElixir, _arch}, _args}, acc -> acc + 1
+    end)
+  end
+
+  defp over_limit?(username, builds_count) do
+    hour_ago = DateTime.add(DateTime.utc_now(), -1, :hour)
+    builds_count_for_user_since(username, hour_ago) + builds_count > @hourly_build_limit
+  end
+
+  defp request_target(%{kind: "erlang"} = request) do
+    "#{request.erlang}-#{request.os}-#{request.os_version}"
+  end
+
+  defp request_target(%{kind: "elixir"} = request) do
+    "#{request.elixir}-erlang-#{request.erlang}-#{request.os}-#{request.os_version}"
+  end
+
+  def create(attrs) do
+    %BuildRequest{}
+    |> BuildRequest.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def pending() do
+    Repo.all(
+      from(request in BuildRequest,
+        where: request.state == "pending",
+        order_by: [asc: request.inserted_at]
+      )
+    )
+  end
+
+  def complete(request), do: set_state(request, "completed")
+
+  def expire(request), do: set_state(request, "expired")
+
+  def builds_count_for_user_since(username, since) do
+    Repo.one(
+      from(request in BuildRequest,
+        where: request.username == ^username and request.inserted_at >= ^since,
+        select: coalesce(sum(request.builds_count), 0)
+      )
+    )
+  end
+
+  def recent_for_user(username, limit \\ 10) do
+    Repo.all(
+      from(request in BuildRequest,
+        where: request.username == ^username,
+        order_by: [desc: request.inserted_at],
+        limit: ^limit
+      )
+    )
+  end
+
+  defp set_state(request, state) do
+    request
+    |> Ecto.Changeset.change(state: state)
+    |> Repo.update!()
+  end
+end

--- a/lib/bob/build_requests.ex
+++ b/lib/bob/build_requests.ex
@@ -97,10 +97,13 @@ defmodule Bob.BuildRequests do
   end
 
   def pending() do
+    Repo.all(pending_query())
+  end
+
+  def pending(limit) when is_integer(limit) and limit > 0 do
     Repo.all(
-      from(request in BuildRequest,
-        where: request.state == "pending",
-        order_by: [asc: request.inserted_at]
+      from(request in pending_query(),
+        limit: ^limit
       )
     )
   end
@@ -125,6 +128,13 @@ defmodule Bob.BuildRequests do
         order_by: [desc: request.inserted_at],
         limit: ^limit
       )
+    )
+  end
+
+  defp pending_query() do
+    from(request in BuildRequest,
+      where: request.state == "pending",
+      order_by: [asc: request.inserted_at]
     )
   end
 

--- a/lib/bob/build_requests/build_request.ex
+++ b/lib/bob/build_requests/build_request.ex
@@ -1,0 +1,27 @@
+defmodule Bob.BuildRequests.BuildRequest do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @fields [:username, :kind, :elixir, :erlang, :os, :os_version, :builds_count]
+  @required [:username, :kind, :erlang, :os, :os_version, :builds_count]
+
+  schema "build_requests" do
+    field(:username, :string)
+    field(:kind, :string)
+    field(:elixir, :string)
+    field(:erlang, :string)
+    field(:os, :string)
+    field(:os_version, :string)
+    field(:builds_count, :integer)
+    field(:state, :string, default: "pending")
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(build_request, attrs) do
+    build_request
+    |> cast(attrs, @fields)
+    |> validate_required(@required)
+    |> validate_inclusion(:kind, ~w(erlang elixir))
+  end
+end

--- a/lib/bob/cache.ex
+++ b/lib/bob/cache.ex
@@ -1,0 +1,39 @@
+defmodule Bob.Cache do
+  @moduledoc """
+  Read-through cache with per-key TTLs for values that are expensive to fetch
+  (GitHub refs, S3 build lists) but fine to serve slightly stale.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def fetch(key, ttl_seconds, fun) do
+    now = System.system_time(:second)
+
+    case :ets.lookup(@table, key) do
+      [{^key, value, expires_at}] when expires_at > now ->
+        value
+
+      _ ->
+        value = fun.()
+        :ets.insert(@table, {key, value, now + ttl_seconds})
+        value
+    end
+  end
+
+  def clear() do
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    {:ok, nil}
+  end
+end

--- a/lib/bob/cache.ex
+++ b/lib/bob/cache.ex
@@ -1,7 +1,7 @@
 defmodule Bob.Cache do
   @moduledoc """
   Read-through cache with per-key TTLs for values that are expensive to fetch
-  (GitHub refs, S3 build lists) but fine to serve slightly stale.
+  (external version metadata, refs) but fine to serve slightly stale.
   """
 
   use GenServer

--- a/lib/bob/github.ex
+++ b/lib/bob/github.ex
@@ -19,6 +19,17 @@ defmodule Bob.GitHub do
     |> github_request()
   end
 
+  # Releases come back newest-first, so the first page is enough to find
+  # anything published recently without paging through years of history.
+  def fetch_recent_releases(repo) do
+    {body, _headers} =
+      repo
+      |> releases_url()
+      |> github_get()
+
+    body
+  end
+
   defp response_to_refs(response) do
     Enum.map(response, fn item ->
       {:binary.copy(item["name"]), :binary.copy(item["commit"]["sha"])}
@@ -26,6 +37,16 @@ defmodule Bob.GitHub do
   end
 
   defp github_request(url) do
+    {body, headers} = github_get(url)
+
+    if url = next_link(headers) do
+      body ++ github_request(url)
+    else
+      body
+    end
+  end
+
+  defp github_get(url) do
     user = Application.get_env(:bob, :github_user)
     token = Application.get_env(:bob, :github_token)
 
@@ -34,13 +55,7 @@ defmodule Bob.GitHub do
     {:ok, 200, headers, body} =
       Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
 
-    body = JSON.decode!(body)
-
-    if url = next_link(headers) do
-      body ++ github_request(url)
-    else
-      body
-    end
+    {JSON.decode!(body), headers}
   end
 
   defp next_link(headers) do

--- a/lib/bob/github.ex
+++ b/lib/bob/github.ex
@@ -3,8 +3,20 @@ defmodule Bob.GitHub do
 
   def fetch_repo_refs(repo) do
     branches = github_request(@github_url <> "repos/#{repo}/branches?per_page=100")
-    tags = github_request(@github_url <> "repos/#{repo}/tags?per_page=100")
-    response_to_refs(branches) ++ response_to_refs(tags)
+    response_to_refs(branches) ++ fetch_repo_tags(repo)
+  end
+
+  def fetch_repo_tags(repo) do
+    repo
+    |> tags_url()
+    |> github_request()
+    |> response_to_refs()
+  end
+
+  def fetch_repo_releases(repo) do
+    repo
+    |> releases_url()
+    |> github_request()
   end
 
   defp response_to_refs(response) do
@@ -17,7 +29,7 @@ defmodule Bob.GitHub do
     user = Application.get_env(:bob, :github_user)
     token = Application.get_env(:bob, :github_token)
 
-    opts = [basic_auth: {user, token}]
+    opts = if user && token, do: [basic_auth: {user, token}], else: []
 
     {:ok, 200, headers, body} =
       Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
@@ -46,4 +58,8 @@ defmodule Bob.GitHub do
       end
     end)
   end
+
+  defp tags_url(repo), do: @github_url <> "repos/#{repo}/tags?per_page=100"
+
+  defp releases_url(repo), do: @github_url <> "repos/#{repo}/releases?per_page=100"
 end

--- a/lib/bob/hexpm.ex
+++ b/lib/bob/hexpm.ex
@@ -1,0 +1,29 @@
+defmodule Bob.Hexpm do
+  @callback exchange_code(
+              code :: String.t(),
+              code_verifier :: String.t(),
+              redirect_uri :: String.t()
+            ) ::
+              {:ok, map()} | {:error, term()}
+  @callback refresh_token(refresh_token :: String.t()) :: {:ok, map()} | {:error, term()}
+  @callback revoke_token(token :: String.t()) :: :ok | {:error, term()}
+  @callback get_current_user(access_token :: String.t()) :: {:ok, map()} | {:error, term()}
+
+  def exchange_code(code, code_verifier, redirect_uri) do
+    impl().exchange_code(code, code_verifier, redirect_uri)
+  end
+
+  def refresh_token(refresh_token) do
+    impl().refresh_token(refresh_token)
+  end
+
+  def revoke_token(token) do
+    impl().revoke_token(token)
+  end
+
+  def get_current_user(access_token) do
+    impl().get_current_user(access_token)
+  end
+
+  defp impl(), do: Application.fetch_env!(:bob, :hexpm_impl)
+end

--- a/lib/bob/hexpm/impl.ex
+++ b/lib/bob/hexpm/impl.ex
@@ -1,0 +1,78 @@
+defmodule Bob.Hexpm.Impl do
+  @behaviour Bob.Hexpm
+
+  # Token requests are not retried: authorization codes are single-use, so a
+  # replay after a flaky response would be rejected by hexpm anyway.
+  @impl true
+  def exchange_code(code, code_verifier, redirect_uri) do
+    token_request(%{
+      "grant_type" => "authorization_code",
+      "code" => code,
+      "redirect_uri" => redirect_uri,
+      "client_id" => Bob.OAuth.client_id(),
+      "client_secret" => Bob.OAuth.client_secret(),
+      "code_verifier" => code_verifier,
+      "name" => "bob.hex.pm"
+    })
+  end
+
+  @impl true
+  def refresh_token(refresh_token) do
+    token_request(%{
+      "grant_type" => "refresh_token",
+      "refresh_token" => refresh_token,
+      "client_id" => Bob.OAuth.client_id(),
+      "client_secret" => Bob.OAuth.client_secret()
+    })
+  end
+
+  @impl true
+  def revoke_token(token) do
+    url = Bob.OAuth.hexpm_url() <> "/api/oauth/revoke"
+    headers = [{"content-type", "application/json"}]
+
+    body =
+      JSON.encode!(%{
+        "token" => token,
+        "client_id" => Bob.OAuth.client_id(),
+        "client_secret" => Bob.OAuth.client_secret()
+      })
+
+    case Bob.HTTP.request(:post, url, headers, body) do
+      {:ok, status, _headers, _body} when status in 200..299 -> :ok
+      {:ok, status, _headers, body} -> {:error, {status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def get_current_user(access_token) do
+    url = Bob.OAuth.hexpm_url() <> "/api/users/me"
+    headers = [{"authorization", "Bearer " <> access_token}, {"accept", "application/json"}]
+
+    :get
+    |> Bob.HTTP.request(url, headers, "")
+    |> read_response()
+  end
+
+  defp token_request(body) do
+    url = Bob.OAuth.hexpm_url() <> "/api/oauth/token"
+    headers = [{"content-type", "application/json"}]
+
+    :post
+    |> Bob.HTTP.request(url, headers, JSON.encode!(body))
+    |> read_response()
+  end
+
+  defp read_response({:ok, status, _headers, body}) when status in 200..299 do
+    {:ok, JSON.decode!(body)}
+  end
+
+  defp read_response({:ok, status, _headers, body}) do
+    {:error, {status, body}}
+  end
+
+  defp read_response({:error, reason}) do
+    {:error, reason}
+  end
+end

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -87,7 +87,7 @@ defmodule Bob.Job.DockerChecker do
   defp erlang_tag_name({erlang, os, os_version, _arch}), do: "#{erlang}-#{os}-#{os_version}"
 
   def expected_erlang_tags() do
-    refs = erlang_refs()
+    refs = latest_erlang_refs(erlang_refs())
 
     Stream.flat_map(builds(), fn {os, os_versions} ->
       Stream.flat_map(refs, fn ref ->
@@ -111,6 +111,20 @@ defmodule Bob.Job.DockerChecker do
         end
       end)
     end)
+  end
+
+  def archs(), do: @archs
+
+  def erlang_versions() do
+    Enum.map(erlang_refs(), fn "OTP-" <> version -> version end)
+  end
+
+  # Whether the build rules allow this erlang/os/os_version combination on all archs.
+  def valid_erlang_build?(erlang, os, os_version) do
+    ref = "OTP-" <> erlang
+
+    build_erlang_ref?(os, ref) and build_erlang_ref?(os, os_version, ref) and
+      Enum.all?(@archs, &build_erlang_ref?(&1, os, os_version, ref))
   end
 
   defp build_erlang_ref?(_os, "OTP-18.0-rc2"), do: false
@@ -222,10 +236,30 @@ defmodule Bob.Job.DockerChecker do
 
   defp erlang_refs() do
     "erlang/otp"
-    |> Bob.GitHub.fetch_repo_refs()
+    |> github().fetch_repo_refs()
     |> Enum.map(fn {ref_name, _ref} -> ref_name end)
     |> Enum.filter(&String.starts_with?(&1, "OTP-"))
     |> Enum.sort(&(cmp_erlang_tags(&1, &2) != :lt))
+  end
+
+  defp github(), do: Application.get_env(:bob, :github, Bob.GitHub)
+
+  # Keeps only the newest ref per OTP major.minor line. Stable releases rank
+  # above prereleases within a line, so RCs drop out once a stable lands.
+  # Selection happens before the per-OS filters: a line whose newest ref an OS
+  # rule rejects gets no older fallback.
+  def latest_erlang_refs(refs) do
+    refs
+    |> Enum.sort(&(cmp_erlang_tags(&1, &2) != :lt))
+    |> Enum.uniq_by(fn "OTP-" <> version ->
+      version |> to_matchable() |> elem(0) |> Enum.take(2)
+    end)
+  end
+
+  defp latest_erlang_versions() do
+    erlang_refs()
+    |> latest_erlang_refs()
+    |> MapSet.new(fn "OTP-" <> version -> version end)
   end
 
   defp cmp_erlang_tags("OTP-" <> left, "OTP-" <> right) do
@@ -293,10 +327,12 @@ defmodule Bob.Job.DockerChecker do
 
   def expected_elixir_tags() do
     builds = builds()
-    refs = elixir_builds()
+    refs = latest_elixir_builds(elixir_builds())
+    latest_erlang = latest_erlang_versions()
 
     Stream.flat_map(current_erlang_tags(builds), fn {erlang, os, os_version, erlang_arch} ->
-      if not skip_elixir_for_erlang?(erlang) and os_version in builds[os] do
+      if MapSet.member?(latest_erlang, erlang) and not skip_elixir_for_erlang?(erlang) and
+           os_version in builds[os] do
         Stream.flat_map(refs, fn {"v" <> elixir, otp_major} ->
           if compatible_elixir_and_erlang?(otp_major, erlang) do
             [{elixir, erlang, os, os_version, erlang_arch}]
@@ -333,6 +369,24 @@ defmodule Bob.Job.DockerChecker do
     |> Enum.sort(&cmp_elixir_tags/2)
     |> Enum.reject(fn {_elixir, otp} -> otp == nil end)
     |> Enum.reject(fn {"v" <> elixir, _otp} -> skip_elixir?(elixir) end)
+  end
+
+  # Whether the build rules allow this elixir build on this exact erlang/os/os_version.
+  def valid_elixir_build?(elixir, otp_major, erlang, os, os_version) do
+    build_elixir_ref?({"v" <> elixir, otp_major}) and not skip_elixir?(elixir) and
+      not skip_elixir_for_erlang?(erlang) and compatible_elixir_and_erlang?(otp_major, erlang) and
+      valid_erlang_build?(erlang, os, os_version)
+  end
+
+  # Keeps only the newest build per {elixir major.minor, otp major} pair.
+  # Stable releases rank above prereleases within a pair.
+  def latest_elixir_builds(builds) do
+    builds
+    |> Enum.sort(&cmp_elixir_tags/2)
+    |> Enum.uniq_by(fn {"v" <> elixir, otp} ->
+      version = Version.parse!(normalize_version(elixir))
+      {version.major, version.minor, otp}
+    end)
   end
 
   defp split_elixir_build(build_name) do

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -70,7 +70,13 @@ defmodule Bob.Job.DockerChecker do
   def concurrency(), do: :shared
 
   def erlang() do
+    recent_os = recent_base_image_versions()
+    recent_otp = recent_erlang_versions()
+
     expected_erlang_tags()
+    |> Enum.filter(fn {erlang, os, os_version, _arch} ->
+      MapSet.member?(recent_os, {os, os_version}) or MapSet.member?(recent_otp, erlang)
+    end)
     |> Enum.group_by(fn {_erlang, _os, _os_version, arch} -> arch end)
     |> Enum.flat_map(fn {arch, expected} ->
       present =
@@ -247,6 +253,59 @@ defmodule Bob.Job.DockerChecker do
 
   defp github(), do: Application.get_env(:bob, :github, Bob.GitHub)
 
+  # Auto-builds only fire when one of the image's components — its base image,
+  # OTP, or Elixir — was released within this window. Old combinations that
+  # Docker Hub prunes for lack of pulls then stay pruned instead of being
+  # rebuilt every cycle; users can still request them explicitly.
+  @build_freshness_days 30
+
+  defp freshness_cutoff() do
+    DateTime.add(DateTime.utc_now(), -@build_freshness_days, :day)
+  end
+
+  defp recent_base_image_versions() do
+    Bob.Artifacts.recent_base_image_versions(freshness_cutoff())
+  end
+
+  defp recent_erlang_versions() do
+    cutoff = freshness_cutoff()
+
+    "erlang/otp"
+    |> github().fetch_recent_releases()
+    |> Enum.flat_map(fn
+      %{"tag_name" => "OTP-" <> version, "published_at" => published_at} ->
+        if release_recent?(published_at, cutoff), do: [version], else: []
+
+      _other ->
+        []
+    end)
+    |> MapSet.new()
+  end
+
+  defp recent_elixir_versions() do
+    cutoff = freshness_cutoff()
+
+    "elixir-lang/elixir"
+    |> github().fetch_recent_releases()
+    |> Enum.flat_map(fn
+      %{"tag_name" => "v" <> version, "published_at" => published_at} ->
+        if release_recent?(published_at, cutoff), do: [version], else: []
+
+      _other ->
+        []
+    end)
+    |> MapSet.new()
+  end
+
+  defp release_recent?(published_at, cutoff) when is_binary(published_at) do
+    case DateTime.from_iso8601(published_at) do
+      {:ok, datetime, _offset} -> DateTime.compare(datetime, cutoff) != :lt
+      _error -> false
+    end
+  end
+
+  defp release_recent?(_published_at, _cutoff), do: false
+
   # Keeps only the newest ref per OTP major.minor line. Stable releases rank
   # above prereleases within a line, so RCs drop out once a stable lands.
   # Selection happens before the per-OS filters: a line whose newest ref an OS
@@ -307,7 +366,15 @@ defmodule Bob.Job.DockerChecker do
   end
 
   def elixir() do
+    recent_os = recent_base_image_versions()
+    recent_otp = recent_erlang_versions()
+    recent_elixir = recent_elixir_versions()
+
     expected_elixir_tags()
+    |> Enum.filter(fn {elixir, erlang, os, os_version, _arch} ->
+      MapSet.member?(recent_os, {os, os_version}) or MapSet.member?(recent_otp, erlang) or
+        MapSet.member?(recent_elixir, elixir)
+    end)
     |> Enum.group_by(fn {_elixir, _erlang, _os, _os_version, arch} -> arch end)
     |> Enum.flat_map(fn {arch, expected} ->
       present =

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -3,6 +3,7 @@ defmodule Bob.Job.DockerChecker do
 
   @erlang_tag_regex ~r"^(.+)-(alpine|ubuntu|debian)-(.+)$"
   @elixir_tag_regex ~r"^(.+)-erlang-(.+)-(alpine|ubuntu|debian)-(.+)$"
+  @elixir_release_asset_regex ~r"^elixir-otp-(\d+)\.zip$"
 
   @archs ["amd64", "arm64"]
   @erlang_arch_repos Enum.map(@archs, &"hexpm/erlang-#{&1}")
@@ -363,13 +364,11 @@ defmodule Bob.Job.DockerChecker do
   end
 
   def elixir_builds() do
-    "builds/elixir"
-    |> Bob.Store.fetch_built_refs()
-    |> Stream.map(fn {build_name, _ref} -> build_name end)
-    |> Stream.map(&split_elixir_build/1)
+    "elixir-lang/elixir"
+    |> github().fetch_repo_releases()
+    |> Stream.flat_map(&release_elixir_builds/1)
     |> Stream.filter(&build_elixir_ref?/1)
     |> Enum.sort(&cmp_elixir_tags/2)
-    |> Enum.reject(fn {_elixir, otp} -> otp == nil end)
     |> Enum.reject(fn {"v" <> elixir, _otp} -> skip_elixir?(elixir) end)
   end
 
@@ -389,13 +388,6 @@ defmodule Bob.Job.DockerChecker do
       version = Version.parse!(normalize_version(elixir))
       {version.major, version.minor, otp}
     end)
-  end
-
-  defp split_elixir_build(build_name) do
-    case String.split(build_name, "-otp-") do
-      [elixir, major_otp] -> {elixir, major_otp}
-      [elixir] -> {elixir, nil}
-    end
   end
 
   defp cmp_elixir_tags({"v" <> elixir_left, otp_left}, {"v" <> elixir_right, otp_right}) do
@@ -427,6 +419,15 @@ defmodule Bob.Job.DockerChecker do
       [_major, _minor | _rest] -> version
       _ -> version
     end
+  end
+
+  defp release_elixir_builds(%{"tag_name" => tag_name, "assets" => assets}) do
+    Enum.flat_map(assets, fn %{"name" => name} ->
+      case Regex.run(@elixir_release_asset_regex, name, capture: :all_but_first) do
+        [otp_major] -> [{tag_name, otp_major}]
+        _other -> []
+      end
+    end)
   end
 
   defp compatible_elixir_and_erlang?(otp_major, erlang) do

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -244,14 +244,24 @@ defmodule Bob.Job.DockerChecker do
   end
 
   defp erlang_refs() do
-    "erlang/otp"
-    |> github().fetch_repo_refs()
+    {:repo_refs, "erlang/otp"}
+    |> cached_github(fn -> github().fetch_repo_refs("erlang/otp") end)
     |> Enum.map(fn {ref_name, _ref} -> ref_name end)
     |> Enum.filter(&String.starts_with?(&1, "OTP-"))
     |> Enum.sort(&(cmp_erlang_tags(&1, &2) != :lt))
   end
 
   defp github(), do: Application.get_env(:bob, :github, Bob.GitHub)
+
+  # A run() calls erlang() then elixir(), and both reach for the same refs and
+  # release lists, so cache the raw GitHub responses briefly to collapse the
+  # duplicate calls within a cycle. The TTL is far below the 15-minute schedule,
+  # so each cycle still fetches fresh.
+  @github_cache_ttl 60
+
+  defp cached_github(key, fun) do
+    Bob.Cache.fetch({__MODULE__, key}, @github_cache_ttl, fun)
+  end
 
   # Auto-builds only fire when one of the image's components — its base image,
   # OTP, or Elixir — was released within this window. Old combinations that
@@ -270,8 +280,8 @@ defmodule Bob.Job.DockerChecker do
   defp recent_erlang_versions() do
     cutoff = freshness_cutoff()
 
-    "erlang/otp"
-    |> github().fetch_recent_releases()
+    {:recent_releases, "erlang/otp"}
+    |> cached_github(fn -> github().fetch_recent_releases("erlang/otp") end)
     |> Enum.flat_map(fn
       %{"tag_name" => "OTP-" <> version, "published_at" => published_at} ->
         if release_recent?(published_at, cutoff), do: [version], else: []
@@ -285,8 +295,8 @@ defmodule Bob.Job.DockerChecker do
   defp recent_elixir_versions() do
     cutoff = freshness_cutoff()
 
-    "elixir-lang/elixir"
-    |> github().fetch_recent_releases()
+    {:recent_releases, "elixir-lang/elixir"}
+    |> cached_github(fn -> github().fetch_recent_releases("elixir-lang/elixir") end)
     |> Enum.flat_map(fn
       %{"tag_name" => "v" <> version, "published_at" => published_at} ->
         if release_recent?(published_at, cutoff), do: [version], else: []
@@ -431,8 +441,8 @@ defmodule Bob.Job.DockerChecker do
   end
 
   def elixir_builds() do
-    "elixir-lang/elixir"
-    |> github().fetch_repo_releases()
+    {:repo_releases, "elixir-lang/elixir"}
+    |> cached_github(fn -> github().fetch_repo_releases("elixir-lang/elixir") end)
     |> Stream.flat_map(&release_elixir_builds/1)
     |> Stream.filter(&build_elixir_ref?/1)
     |> Enum.sort(&cmp_elixir_tags/2)

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -476,13 +476,16 @@ defmodule Bob.Job.DockerChecker do
     %{erlang: erlang, os: os, os_version: os_version} = request
     tag = "#{erlang}-#{os}-#{os_version}"
 
-    Enum.flat_map(@archs, fn arch ->
-      if tag_present?("hexpm/erlang-#{arch}", tag) do
-        []
-      else
-        [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
-      end
-    end)
+    arch_jobs =
+      Enum.flat_map(@archs, fn arch ->
+        if tag_present?("hexpm/erlang-#{arch}", tag) do
+          []
+        else
+          [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
+        end
+      end)
+
+    arch_jobs ++ manifest_jobs(arch_jobs, "erlang", tag, {erlang, os, os_version})
   end
 
   # The elixir image is built FROM the erlang image, and failed jobs are not
@@ -494,18 +497,41 @@ defmodule Bob.Job.DockerChecker do
     erlang_tag = "#{erlang}-#{os}-#{os_version}"
     elixir_tag = "#{elixir}-erlang-#{erlang}-#{os}-#{os_version}"
 
-    Enum.flat_map(@archs, fn arch ->
-      cond do
-        tag_present?("hexpm/elixir-#{arch}", elixir_tag) ->
-          []
+    arch_jobs =
+      Enum.flat_map(@archs, fn arch ->
+        cond do
+          tag_present?("hexpm/elixir-#{arch}", elixir_tag) ->
+            []
 
-        tag_present?("hexpm/erlang-#{arch}", erlang_tag) ->
-          [{{Bob.Job.BuildDockerElixir, arch}, [elixir, erlang, os, os_version]}]
+          tag_present?("hexpm/erlang-#{arch}", erlang_tag) ->
+            [{{Bob.Job.BuildDockerElixir, arch}, [elixir, erlang, os, os_version]}]
 
-        true ->
-          [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
-      end
-    end)
+          true ->
+            [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
+        end
+      end)
+
+    arch_jobs ++ manifest_jobs(arch_jobs, "elixir", elixir_tag, {elixir, erlang, os, os_version})
+  end
+
+  # A request is only done once its manifest spans every architecture, so while
+  # the per-arch tags are still building we wait, and once they exist we enqueue
+  # the manifest ourselves rather than relying solely on manifest/0.
+  defp manifest_jobs(pending_arch_jobs, _kind, _tag, _key) when pending_arch_jobs != [], do: []
+
+  defp manifest_jobs([], kind, tag, key) do
+    if manifest_complete?(kind, tag) do
+      []
+    else
+      [{Bob.Job.DockerManifest, [kind, key]}]
+    end
+  end
+
+  defp manifest_complete?(kind, tag) do
+    case Bob.Artifacts.docker_tag_archs("hexpm/#{kind}", tag) do
+      nil -> false
+      archs -> Enum.all?(@archs, &(&1 in archs))
+    end
   end
 
   defp tag_present?(repo, tag) do

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -55,11 +55,13 @@ defmodule Bob.Job.DockerChecker do
   def run() do
     erlang()
     elixir()
+    requests()
     manifest()
   end
 
   def run(:erlang), do: erlang()
   def run(:elixir), do: elixir()
+  def run(:requests), do: requests()
   def run(:manifest), do: manifest()
 
   def priority(), do: 1
@@ -440,6 +442,75 @@ defmodule Bob.Job.DockerChecker do
 
   defp skip_elixir?(elixir) do
     Version.compare(normalize_version(elixir), "1.10.0-0") == :lt
+  end
+
+  # Requests that still have no tags after this long are unbuildable; expiring
+  # them stops the reconciliation from re-enqueueing doomed jobs forever.
+  @request_ttl_days 14
+
+  # User-requested builds are one-time: pinned to the os_version current at
+  # request time and reconciled here until every target tag exists. Requests
+  # whose os_version rotated out of builds() expire instead.
+  def requests() do
+    builds = builds()
+
+    Enum.each(Bob.BuildRequests.pending(), fn request ->
+      cond do
+        request.os_version not in Map.get(builds, request.os, []) ->
+          Bob.BuildRequests.expire(request)
+
+        DateTime.diff(DateTime.utc_now(), request.inserted_at, :day) >= @request_ttl_days ->
+          Bob.BuildRequests.expire(request)
+
+        true ->
+          case request_jobs(request) do
+            [] -> Bob.BuildRequests.complete(request)
+            jobs -> Bob.Queue.add_many(jobs)
+          end
+      end
+    end)
+  end
+
+  def request_jobs(%{kind: "erlang"} = request) do
+    %{erlang: erlang, os: os, os_version: os_version} = request
+    tag = "#{erlang}-#{os}-#{os_version}"
+
+    Enum.flat_map(@archs, fn arch ->
+      if tag_present?("hexpm/erlang-#{arch}", tag) do
+        []
+      else
+        [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
+      end
+    end)
+  end
+
+  # The elixir image is built FROM the erlang image, and failed jobs are not
+  # retried by the queue, so the elixir job is only enqueued once its base tag
+  # exists; until then the erlang build is enqueued and the next reconciliation
+  # cycle picks the request up again.
+  def request_jobs(%{kind: "elixir"} = request) do
+    %{elixir: elixir, erlang: erlang, os: os, os_version: os_version} = request
+    erlang_tag = "#{erlang}-#{os}-#{os_version}"
+    elixir_tag = "#{elixir}-erlang-#{erlang}-#{os}-#{os_version}"
+
+    Enum.flat_map(@archs, fn arch ->
+      cond do
+        tag_present?("hexpm/elixir-#{arch}", elixir_tag) ->
+          []
+
+        tag_present?("hexpm/erlang-#{arch}", erlang_tag) ->
+          [{{Bob.Job.BuildDockerElixir, arch}, [elixir, erlang, os, os_version]}]
+
+        true ->
+          [{{Bob.Job.BuildDockerErlang, arch}, [erlang, os, os_version]}]
+      end
+    end)
+  end
+
+  defp tag_present?(repo, tag) do
+    repo
+    |> Bob.Artifacts.docker_tags_present([tag])
+    |> MapSet.member?(tag)
   end
 
   def manifest() do

--- a/lib/bob/oauth.ex
+++ b/lib/bob/oauth.ex
@@ -1,0 +1,43 @@
+defmodule Bob.OAuth do
+  @moduledoc """
+  OAuth 2.0 Authorization Code with PKCE helpers for authenticating against hexpm.
+  """
+
+  def generate_code_verifier() do
+    :crypto.strong_rand_bytes(32)
+    |> Base.url_encode64(padding: false)
+  end
+
+  def generate_code_challenge(verifier) do
+    :crypto.hash(:sha256, verifier)
+    |> Base.url_encode64(padding: false)
+  end
+
+  def generate_state() do
+    :crypto.strong_rand_bytes(16)
+    |> Base.url_encode64(padding: false)
+  end
+
+  def authorization_url(opts) do
+    state = Keyword.fetch!(opts, :state)
+    code_challenge = Keyword.fetch!(opts, :code_challenge)
+    redirect_uri = Keyword.fetch!(opts, :redirect_uri)
+
+    query =
+      URI.encode_query(%{
+        "response_type" => "code",
+        "client_id" => client_id(),
+        "redirect_uri" => redirect_uri,
+        "scope" => "api:read",
+        "state" => state,
+        "code_challenge" => code_challenge,
+        "code_challenge_method" => "S256"
+      })
+
+    "#{hexpm_url()}/oauth/authorize?#{query}"
+  end
+
+  def hexpm_url(), do: Application.fetch_env!(:bob, :hexpm_url)
+  def client_id(), do: Application.fetch_env!(:bob, :oauth_client_id)
+  def client_secret(), do: Application.fetch_env!(:bob, :oauth_client_secret)
+end

--- a/lib/bob/queue/maintenance.ex
+++ b/lib/bob/queue/maintenance.ex
@@ -2,8 +2,8 @@ defmodule Bob.Queue.Maintenance do
   @moduledoc """
   Periodic queue maintenance, guarded by a Postgres advisory lock so exactly
   one master instance does the work: requeues stale running jobs (failing them
-  once their requeues are exhausted), prunes expired backoff rows, and prunes
-  old job history.
+  once their requeues are exhausted), prunes expired backoff rows, prunes old
+  job history, and prunes old build requests.
   """
 
   use GenServer
@@ -21,6 +21,7 @@ defmodule Bob.Queue.Maintenance do
   @max_timeout_requeues 2
   @backoff_expiry_seconds 7 * 24 * 60 * 60
   @history_retention_seconds 90 * 24 * 60 * 60
+  @build_request_retention_seconds 90 * 24 * 60 * 60
   @advisory_lock_key 4_771_001
 
   def start_link([]) do
@@ -48,6 +49,7 @@ defmodule Bob.Queue.Maintenance do
           sweep_stale_running()
           prune_failures()
           prune_history()
+          prune_build_requests()
         end
       end)
 
@@ -99,6 +101,10 @@ defmodule Bob.Queue.Maintenance do
     Repo.delete_all(
       from(j in Job, where: j.state in ["done", "failed"] and j.finished_at < ^cutoff)
     )
+  end
+
+  defp prune_build_requests() do
+    Bob.BuildRequests.prune(@build_request_retention_seconds)
   end
 
   defp schedule_tick() do

--- a/lib/bob/store.ex
+++ b/lib/bob/store.ex
@@ -1,21 +1,6 @@
 defmodule Bob.Store do
   @bucket "s3.hex.pm"
 
-  # TODO: Use S3 object metadata
-  def fetch_built_refs(build_path) do
-    path = Path.join(build_path, "builds.txt")
-
-    case ExAws.S3.get_object(@bucket, path, []) |> ExAws.request() do
-      {:ok, %{body: body}} ->
-        body
-        |> String.split("\n", trim: true)
-        |> Map.new(&line_to_ref/1)
-
-      {:error, {:http_error, 404, _}} ->
-        %{}
-    end
-  end
-
   def fetch_file(path) do
     %{body: body} = ExAws.S3.get_object(@bucket, path, []) |> ExAws.request!()
     body
@@ -37,10 +22,5 @@ defmodule Bob.Store do
     ExAws.S3.list_objects(@bucket, prefix: prefix)
     |> ExAws.stream!()
     |> Stream.map(&Map.get(&1, :key))
-  end
-
-  defp line_to_ref(line) do
-    destructure [ref_name, ref], String.split(line, " ", trim: true)
-    {ref_name, ref}
   end
 end

--- a/lib/bob_web/components/core_components.ex
+++ b/lib/bob_web/components/core_components.ex
@@ -228,13 +228,17 @@ defmodule BobWeb.CoreComponents do
   attr(:value, :string, default: "")
   attr(:options, :list, required: true)
   attr(:disabled, :boolean, default: false)
+  # nil renders a selectable "any" option (filters); a string renders a
+  # non-selectable placeholder (forms that demand an explicit choice).
+  attr(:prompt, :string, default: nil)
 
   def filter_select(assigns) do
     ~H"""
     <label class={["fsel", @disabled && "fsel--off"]}>
       <span class="fsel__label"><%= @label %>:</span>
       <select name={@name} disabled={@disabled}>
-        <option value="">any</option>
+        <option :if={@prompt} value="" disabled selected={@value == ""} hidden><%= @prompt %></option>
+        <option :if={!@prompt} value="">any</option>
         <option :for={option <- @options} value={option} selected={option == @value}><%= option %></option>
       </select>
       <.icon name="chevD" size={13} />

--- a/lib/bob_web/components/layouts.ex
+++ b/lib/bob_web/components/layouts.ex
@@ -18,6 +18,7 @@ defmodule BobWeb.Layouts do
   defp nav_active?("/", "/"), do: true
   defp nav_active?("/artifacts", "/artifacts"), do: true
   defp nav_active?("/docker", "/docker"), do: true
+  defp nav_active?("/request", "/request"), do: true
   defp nav_active?(_current_path, _target_path), do: false
 
   embed_templates("layouts/*")

--- a/lib/bob_web/components/layouts/root.html.heex
+++ b/lib/bob_web/components/layouts/root.html.heex
@@ -43,6 +43,12 @@
             >
               <.icon name="external" /> hexpm/bob
             </a>
+            <%= if assigns[:current_user] do %>
+              <span class="nav-user">{@current_user["username"]}</span>
+              <.link class="nav-ext" href={~p"/oauth/logout"} method="post">Log out</.link>
+            <% else %>
+              <.link class="nav-ext" href={~p"/oauth/login"}>Log in</.link>
+            <% end %>
           </div>
 
           <details class="bob-menu">
@@ -68,6 +74,15 @@
               >
                 <.icon name="external" /> hexpm/bob
               </a>
+              <%= if assigns[:current_user] do %>
+                <.link class="bob-menu__item" href={~p"/oauth/logout"} method="post">
+                  Log out ({@current_user["username"]})
+                </.link>
+              <% else %>
+                <.link class="bob-menu__item" href={~p"/oauth/login"}>
+                  Log in
+                </.link>
+              <% end %>
             </nav>
           </details>
         </div>

--- a/lib/bob_web/components/layouts/root.html.heex
+++ b/lib/bob_web/components/layouts/root.html.heex
@@ -32,6 +32,9 @@
             <.link href={~p"/docker"} class={nav_class(@conn.request_path, "/docker")}>
               <.icon name="docker" /> Docker Tags
             </.link>
+            <.link href={~p"/request"} class={nav_class(@conn.request_path, "/request")}>
+              <.icon name="box" /> Request Build
+            </.link>
           </nav>
 
           <div class="bob-nav__right">
@@ -65,6 +68,9 @@
               </.link>
               <.link href={~p"/docker"} class={menu_class(@conn.request_path, "/docker")}>
                 <.icon name="docker" /> Docker Tags
+              </.link>
+              <.link href={~p"/request"} class={menu_class(@conn.request_path, "/request")}>
+                <.icon name="box" /> Request Build
               </.link>
               <a
                 class="bob-menu__item bob-menu__item--external"

--- a/lib/bob_web/components/layouts/root.html.heex
+++ b/lib/bob_web/components/layouts/root.html.heex
@@ -19,7 +19,6 @@
           <.link href={~p"/"} class="bob-brand">
             <img src={~p"/favicon.ico"} width="28" height="28" alt="" />
             <span class="bob-brand__name">Bob</span>
-            <span class="bob-brand__tag">Hex build server</span>
           </.link>
 
           <nav class="bob-nav__tabs" aria-label="Primary">

--- a/lib/bob_web/controllers/oauth_controller.ex
+++ b/lib/bob_web/controllers/oauth_controller.ex
@@ -1,0 +1,86 @@
+defmodule BobWeb.OAuthController do
+  use BobWeb, :controller
+
+  import BobWeb.UserAuth, only: [safe_return_path: 1, log_in_user: 3, log_out_user: 1]
+
+  require Logger
+
+  def login(conn, params) do
+    return_to =
+      safe_return_path(params["return_to"] || get_session(conn, "oauth_return_to") || "/")
+
+    if conn.assigns[:current_user] do
+      redirect(conn, to: return_to)
+    else
+      code_verifier = Bob.OAuth.generate_code_verifier()
+      state = Bob.OAuth.generate_state()
+
+      authorization_url =
+        Bob.OAuth.authorization_url(
+          state: state,
+          code_challenge: Bob.OAuth.generate_code_challenge(code_verifier),
+          redirect_uri: url(~p"/oauth/callback")
+        )
+
+      conn
+      |> put_session("oauth_state", state)
+      |> put_session("oauth_code_verifier", code_verifier)
+      |> put_session("oauth_return_to", return_to)
+      |> redirect(external: authorization_url)
+    end
+  end
+
+  def callback(conn, params) do
+    cond do
+      error = params["error"] ->
+        auth_error(conn, params["error_description"] || error)
+
+      params["state"] == nil or params["state"] != get_session(conn, "oauth_state") ->
+        auth_error(conn, "invalid OAuth state")
+
+      params["code"] == nil ->
+        auth_error(conn, "missing OAuth code")
+
+      true ->
+        exchange_code(conn, params["code"])
+    end
+  end
+
+  def logout(conn, _params) do
+    if refresh_token = get_session(conn, "refresh_token") do
+      case Bob.Hexpm.revoke_token(refresh_token) do
+        :ok -> :ok
+        {:error, reason} -> Logger.warning("OAUTH token revocation failed: #{inspect(reason)}")
+      end
+    end
+
+    conn
+    |> log_out_user()
+    |> redirect(to: ~p"/")
+  end
+
+  defp exchange_code(conn, code) do
+    code_verifier = get_session(conn, "oauth_code_verifier")
+    return_to = safe_return_path(get_session(conn, "oauth_return_to") || "/")
+
+    with {:ok, tokens} <- Bob.Hexpm.exchange_code(code, code_verifier, url(~p"/oauth/callback")),
+         {:ok, user} <- Bob.Hexpm.get_current_user(tokens["access_token"]) do
+      conn
+      |> delete_session("oauth_state")
+      |> delete_session("oauth_code_verifier")
+      |> delete_session("oauth_return_to")
+      |> log_in_user(%{"username" => user["username"]}, tokens)
+      |> redirect(to: return_to)
+    else
+      {:error, reason} ->
+        Logger.error("OAUTH code exchange failed: #{inspect(reason)}")
+        auth_error(conn, "logging in to hex.pm failed")
+    end
+  end
+
+  defp auth_error(conn, message) do
+    conn
+    |> put_flash(:error, "Authentication failed: #{message}")
+    |> redirect(to: ~p"/")
+  end
+end

--- a/lib/bob_web/endpoint.ex
+++ b/lib/bob_web/endpoint.ex
@@ -6,6 +6,8 @@ defmodule BobWeb.Endpoint do
     store: :cookie,
     key: "_bob_key",
     signing_salt: "9kLm2Qx7",
+    encryption_salt: "X4vR7nTq",
+    max_age: 60 * 60 * 24 * 30,
     same_site: "Lax"
   ]
 
@@ -36,8 +38,8 @@ defmodule BobWeb.Endpoint do
   plug(BobWeb.Plugs.Secret, api_only: true)
 
   plug(Plug.Parsers,
-    parsers: [:json, Bob.Plug.Parser],
-    pass: ["application/json", "application/vnd.bob+erlang"],
+    parsers: [:urlencoded, :json, Bob.Plug.Parser],
+    pass: ["application/x-www-form-urlencoded", "application/json", "application/vnd.bob+erlang"],
     json_decoder: JSON
   )
 

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -7,6 +7,7 @@ defmodule BobWeb.RequestLive do
 
   @options_ttl 10 * 60
   @pending_limit 25
+  @recent_page 50
 
   @impl true
   def mount(_params, _session, socket) do
@@ -30,9 +31,13 @@ defmodule BobWeb.RequestLive do
         os_version: "",
         erlang: "",
         elixir: "",
-        pending_requests: pending_requests(),
-        my_requests: my_requests(socket)
+        recent_page: @recent_page,
+        recent_offset: 0,
+        recent_total: nil,
+        recent_requests: [],
+        pending_requests: pending_requests()
       )
+      |> load_recent()
 
     socket =
       if connected?(socket) do
@@ -76,6 +81,14 @@ defmodule BobWeb.RequestLive do
         {:noreply, submit(socket)}
     end
   end
+
+  def handle_event("page", %{"dir" => dir}, socket) do
+    offset = max(socket.assigns.recent_offset + step(dir), 0)
+    {:noreply, socket |> assign(recent_offset: offset) |> load_recent()}
+  end
+
+  defp step("next"), do: @recent_page
+  defp step("prev"), do: -@recent_page
 
   # Selected values are only kept when they appear in the option lists, which
   # are derived from real refs and builds and already encode the build rules.
@@ -143,15 +156,29 @@ defmodule BobWeb.RequestLive do
   end
 
   defp reload_request_lists(socket) do
-    assign(socket, pending_requests: pending_requests(), my_requests: my_requests(socket))
+    socket
+    |> assign(pending_requests: pending_requests(), recent_offset: 0)
+    |> load_recent()
   end
 
   defp pending_requests() do
     BuildRequests.pending(@pending_limit)
   end
 
-  defp my_requests(socket) do
-    BuildRequests.recent_for_user(socket.assigns.current_user["username"])
+  defp load_recent(socket) do
+    offset = socket.assigns.recent_offset
+    recent = BuildRequests.recent(@recent_page, offset)
+
+    total =
+      if offset == 0 and recent == [] do
+        0
+      else
+        # The page and count are separate queries, so keep the pager coherent
+        # if requests are added or pruned between them.
+        max(BuildRequests.count(), offset + length(recent))
+      end
+
+    assign(socket, recent_requests: recent, recent_total: total)
   end
 
   defp load_options() do
@@ -302,8 +329,11 @@ defmodule BobWeb.RequestLive do
         <div :if={@pending_requests == []} class="empty-mini">No pending requests.</div>
       </.section>
 
-      <.section :if={@my_requests != []} title="Your recent requests" icon="clock">
-        <.table rows={@my_requests} class="jt--req">
+      <.section title="Recent requests" count={@recent_total} icon="clock">
+        <.table :if={@recent_requests != []} rows={@recent_requests} class="jt--req">
+          <:col :let={request} label="user">
+            <span class="mono-cell mono-cell--name"><%= request.username %></span>
+          </:col>
           <:col :let={request} label="image">
             <%= request.kind %>
           </:col>
@@ -317,6 +347,16 @@ defmodule BobWeb.RequestLive do
             <span class="c-time"><%= fmt(request.inserted_at) %></span>
           </:col>
         </.table>
+        <div :if={@recent_requests == []} class="empty-mini">No requests yet.</div>
+
+        <.pager
+          event="page"
+          offset={@recent_offset}
+          count={length(@recent_requests)}
+          page={@recent_page}
+          unit="requests"
+          total={@recent_total}
+        />
       </.section>
     </div>
     """

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -273,9 +273,15 @@ defmodule BobWeb.RequestLive do
         </p>
 
         <form phx-change="validate" phx-submit="request" class="filter-bar filter-bar--wrap">
-          <.form_select name="kind" label="image" value={@kind} options={~w(erlang elixir)} />
-          <.form_select name="os" label="os" value={@os} options={@oses} prompt="Select OS" />
-          <.form_select
+          <.filter_select
+            name="kind"
+            label="image"
+            value={@kind}
+            options={~w(erlang elixir)}
+            prompt="Select image"
+          />
+          <.filter_select name="os" label="os" value={@os} options={@oses} prompt="Select OS" />
+          <.filter_select
             name="os_version"
             label="os version"
             value={@os_version}
@@ -283,7 +289,7 @@ defmodule BobWeb.RequestLive do
             disabled={@os == ""}
             prompt="Select OS version"
           />
-          <.form_select
+          <.filter_select
             name="erlang"
             label="erlang"
             value={@erlang}
@@ -291,7 +297,7 @@ defmodule BobWeb.RequestLive do
             disabled={@erlang_versions == nil or @os_version == ""}
             prompt="Select Erlang"
           />
-          <.form_select
+          <.filter_select
             :if={@kind == "elixir"}
             name="elixir"
             label="elixir"
@@ -359,30 +365,6 @@ defmodule BobWeb.RequestLive do
         />
       </.section>
     </div>
-    """
-  end
-
-  attr(:name, :string, required: true)
-  attr(:label, :string, required: true)
-  attr(:value, :string, default: "")
-  attr(:options, :list, required: true)
-  attr(:disabled, :boolean, default: false)
-  attr(:prompt, :string, default: nil)
-
-  defp form_select(assigns) do
-    ~H"""
-    <label class={["fsel", @disabled && "fsel--off"]}>
-      <span class="fsel__label"><%= @label %>:</span>
-      <select name={@name} disabled={@disabled}>
-        <option :if={@prompt} value="" disabled selected={@value == ""} hidden>
-          <%= @prompt %>
-        </option>
-        <option :for={option <- @options} value={option} selected={option == @value}>
-          <%= option %>
-        </option>
-      </select>
-      <.icon name="chevD" size={13} />
-    </label>
     """
   end
 end

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -6,6 +6,7 @@ defmodule BobWeb.RequestLive do
   alias Bob.Job.DockerChecker
 
   @options_ttl 10 * 60
+  @pending_limit 25
 
   @impl true
   def mount(_params, _session, socket) do
@@ -29,6 +30,7 @@ defmodule BobWeb.RequestLive do
         os_version: "",
         erlang: "",
         elixir: "",
+        pending_requests: pending_requests(),
         my_requests: my_requests(socket)
       )
 
@@ -115,7 +117,7 @@ defmodule BobWeb.RequestLive do
     case BuildRequests.submit(attrs) do
       {:ok, %BuildRequest{}} ->
         socket
-        |> assign(my_requests: my_requests(socket))
+        |> reload_request_lists()
         |> replace_flash(:info, "Build queued, follow the progress on the jobs dashboard.")
 
       {:ok, :already_built} ->
@@ -138,6 +140,14 @@ defmodule BobWeb.RequestLive do
     socket
     |> clear_flash()
     |> put_flash(kind, message)
+  end
+
+  defp reload_request_lists(socket) do
+    assign(socket, pending_requests: pending_requests(), my_requests: my_requests(socket))
+  end
+
+  defp pending_requests() do
+    BuildRequests.pending(@pending_limit)
   end
 
   defp my_requests(socket) do
@@ -273,6 +283,24 @@ defmodule BobWeb.RequestLive do
           first and the Elixir image follows automatically afterwards.
         </div>
       </section>
+
+      <.section title="Pending requests" count={length(@pending_requests)} icon="queue">
+        <.table :if={@pending_requests != []} rows={@pending_requests} class="jt--req">
+          <:col :let={request} label="user">
+            <span class="mono-cell mono-cell--name"><%= request.username %></span>
+          </:col>
+          <:col :let={request} label="image">
+            <span class="kind-badge"><%= request.kind %></span>
+          </:col>
+          <:col :let={request} label="tag">
+            <code class="dk-tag-code" title={target(request)}><%= target(request) %></code>
+          </:col>
+          <:col :let={request} label="requested">
+            <span class="c-time"><%= fmt(request.inserted_at) %></span>
+          </:col>
+        </.table>
+        <div :if={@pending_requests == []} class="empty-mini">No pending requests.</div>
+      </.section>
 
       <.section :if={@my_requests != []} title="Your recent requests" icon="clock">
         <.table rows={@my_requests} class="jt--req">

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -28,7 +28,7 @@ defmodule BobWeb.RequestLive do
         os: "",
         os_version: "",
         erlang: "",
-        elixir_build: "",
+        elixir: "",
         my_requests: my_requests(socket)
       )
 
@@ -48,12 +48,13 @@ defmodule BobWeb.RequestLive do
   end
 
   def handle_async(:options, {:exit, _reason}, socket) do
-    {:noreply, put_flash(socket, :error, "Loading versions failed, reload the page to retry.")}
+    {:noreply,
+     replace_flash(socket, :error, "Loading versions failed, reload the page to retry.")}
   end
 
   @impl true
   def handle_event("validate", params, socket) do
-    {:noreply, apply_form(socket, params)}
+    {:noreply, socket |> apply_form(params) |> clear_flash()}
   end
 
   def handle_event("request", params, socket) do
@@ -62,11 +63,12 @@ defmodule BobWeb.RequestLive do
 
     cond do
       socket.assigns.erlang_versions == nil ->
-        {:noreply, put_flash(socket, :error, "Versions are still loading, try again shortly.")}
+        {:noreply,
+         replace_flash(socket, :error, "Versions are still loading, try again shortly.")}
 
       os == "" or os_version == "" or erlang == "" or
-          (kind == "elixir" and socket.assigns.elixir_build == "") ->
-        {:noreply, put_flash(socket, :error, "Select a value for every field.")}
+          (kind == "elixir" and socket.assigns.elixir == "") ->
+        {:noreply, replace_flash(socket, :error, "Select a value for every field.")}
 
       true ->
         {:noreply, submit(socket)}
@@ -82,17 +84,18 @@ defmodule BobWeb.RequestLive do
     os = keep_member(params["os"], socket.assigns.oses)
     os_version = keep_member(params["os_version"], Map.get(socket.assigns.builds, os, []))
 
-    elixir_build =
+    assigns = %{socket.assigns | kind: kind, os: os, os_version: os_version}
+    erlang = keep_member(params["erlang"], erlang_options(assigns))
+    assigns = %{assigns | erlang: erlang}
+
+    elixir =
       if kind == "elixir" do
-        keep_member(params["elixir_build"], elixir_build_options(socket.assigns.elixir_builds))
+        keep_member(params["elixir"], elixir_options(assigns))
       else
         ""
       end
 
-    socket =
-      assign(socket, kind: kind, os: os, os_version: os_version, elixir_build: elixir_build)
-
-    assign(socket, erlang: keep_member(params["erlang"], erlang_options(socket.assigns)))
+    assign(socket, kind: kind, os: os, os_version: os_version, elixir: elixir, erlang: erlang)
   end
 
   defp keep_member(value, options) do
@@ -113,13 +116,13 @@ defmodule BobWeb.RequestLive do
       {:ok, %BuildRequest{}} ->
         socket
         |> assign(my_requests: my_requests(socket))
-        |> put_flash(:info, "Build queued, follow the progress on the jobs dashboard.")
+        |> replace_flash(:info, "Build queued, follow the progress on the jobs dashboard.")
 
       {:ok, :already_built} ->
-        put_flash(socket, :info, "This image is already built, find it under Docker tags.")
+        replace_flash(socket, :info, "This image is already built, find it under Docker tags.")
 
       {:error, :rate_limited} ->
-        put_flash(
+        replace_flash(
           socket,
           :error,
           "You reached the limit of #{BuildRequests.hourly_build_limit()} requested builds " <>
@@ -127,8 +130,14 @@ defmodule BobWeb.RequestLive do
         )
 
       {:error, :invalid_combo} ->
-        put_flash(socket, :error, "This combination is not supported by the build rules.")
+        replace_flash(socket, :error, "This combination is not supported by the build rules.")
     end
+  end
+
+  defp replace_flash(socket, kind, message) do
+    socket
+    |> clear_flash()
+    |> put_flash(kind, message)
   end
 
   defp my_requests(socket) do
@@ -151,36 +160,35 @@ defmodule BobWeb.RequestLive do
   defp erlang_options(assigns) do
     %{erlang_versions: versions, os: os, os_version: os_version} = assigns
 
-    case {assigns.kind, decode_elixir_build(assigns.elixir_build)} do
-      {"elixir", {elixir, otp_major}} ->
-        Enum.filter(
-          versions,
-          &DockerChecker.valid_elixir_build?(elixir, otp_major, &1, os, os_version)
-        )
+    Enum.filter(versions, &DockerChecker.valid_erlang_build?(&1, os, os_version))
+  end
+
+  defp elixir_options(%{elixir_builds: nil}), do: []
+  defp elixir_options(%{erlang: ""}), do: []
+
+  defp elixir_options(%{
+         elixir_builds: elixir_builds,
+         erlang: erlang,
+         os: os,
+         os_version: os_version
+       }) do
+    otp_major = otp_major(erlang)
+
+    elixir_builds
+    |> Enum.filter(fn
+      {"v" <> elixir, ^otp_major} ->
+        DockerChecker.valid_elixir_build?(elixir, otp_major, erlang, os, os_version)
 
       _other ->
-        Enum.filter(versions, &DockerChecker.valid_erlang_build?(&1, os, os_version))
-    end
+        false
+    end)
+    |> Enum.map(fn {"v" <> elixir, _otp_major} -> elixir end)
+    |> Enum.uniq()
   end
 
-  defp elixir_build_options(nil), do: []
+  defp otp_major(erlang), do: erlang |> String.split(".") |> hd()
 
-  defp elixir_build_options(elixir_builds) do
-    Enum.map(elixir_builds, fn {"v" <> elixir, otp_major} -> "#{elixir}-otp-#{otp_major}" end)
-  end
-
-  defp decode_elixir_build(""), do: nil
-
-  defp decode_elixir_build(elixir_build) do
-    [elixir, otp_major] = String.split(elixir_build, "-otp-")
-    {elixir, otp_major}
-  end
-
-  defp selected_elixir(%{kind: "elixir", elixir_build: elixir_build}) do
-    {elixir, _otp_major} = decode_elixir_build(elixir_build)
-    elixir
-  end
-
+  defp selected_elixir(%{kind: "elixir", elixir: elixir}), do: elixir
   defp selected_elixir(_assigns), do: nil
 
   # The erlang base image gets built first when it is missing; surface that so
@@ -229,21 +237,14 @@ defmodule BobWeb.RequestLive do
 
         <form phx-change="validate" phx-submit="request" class="filter-bar filter-bar--wrap">
           <.form_select name="kind" label="image" value={@kind} options={~w(erlang elixir)} />
-          <.form_select name="os" label="os" value={@os} options={@oses} />
+          <.form_select name="os" label="os" value={@os} options={@oses} prompt="Select OS" />
           <.form_select
             name="os_version"
             label="os version"
             value={@os_version}
             options={Map.get(@builds, @os, [])}
             disabled={@os == ""}
-          />
-          <.form_select
-            :if={@kind == "elixir"}
-            name="elixir_build"
-            label="elixir"
-            value={@elixir_build}
-            options={elixir_build_options(@elixir_builds)}
-            disabled={@elixir_builds == nil}
+            prompt="Select OS version"
           />
           <.form_select
             name="erlang"
@@ -251,6 +252,16 @@ defmodule BobWeb.RequestLive do
             value={@erlang}
             options={erlang_options(assigns)}
             disabled={@erlang_versions == nil or @os_version == ""}
+            prompt="Select Erlang"
+          />
+          <.form_select
+            :if={@kind == "elixir"}
+            name="elixir"
+            label="elixir"
+            value={@elixir}
+            options={elixir_options(assigns)}
+            disabled={@elixir_builds == nil or @erlang == ""}
+            prompt="Select Elixir"
           />
           <button class="pg-btn" type="submit">Request build</button>
         </form>
@@ -263,9 +274,7 @@ defmodule BobWeb.RequestLive do
         </div>
       </section>
 
-      <section :if={@my_requests != []} class="sec">
-        <h2 class="req-heading">Your recent requests</h2>
-
+      <.section :if={@my_requests != []} title="Your recent requests" icon="clock">
         <.table rows={@my_requests} class="jt--req">
           <:col :let={request} label="image">
             <%= request.kind %>
@@ -280,7 +289,7 @@ defmodule BobWeb.RequestLive do
             <span class="c-time"><%= fmt(request.inserted_at) %></span>
           </:col>
         </.table>
-      </section>
+      </.section>
     </div>
     """
   end
@@ -290,13 +299,16 @@ defmodule BobWeb.RequestLive do
   attr(:value, :string, default: "")
   attr(:options, :list, required: true)
   attr(:disabled, :boolean, default: false)
+  attr(:prompt, :string, default: nil)
 
   defp form_select(assigns) do
     ~H"""
     <label class={["fsel", @disabled && "fsel--off"]}>
       <span class="fsel__label"><%= @label %>:</span>
       <select name={@name} disabled={@disabled}>
-        <option value="">choose</option>
+        <option :if={@prompt} value="" disabled selected={@value == ""} hidden>
+          <%= @prompt %>
+        </option>
         <option :for={option <- @options} value={option} selected={option == @value}>
           <%= option %>
         </option>

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -1,0 +1,308 @@
+defmodule BobWeb.RequestLive do
+  use BobWeb, :live_view
+
+  alias Bob.BuildRequests
+  alias Bob.BuildRequests.BuildRequest
+  alias Bob.Job.DockerChecker
+
+  @options_ttl 10 * 60
+
+  @impl true
+  def mount(_params, _session, socket) do
+    builds = DockerChecker.builds()
+
+    oses =
+      builds
+      |> Enum.filter(fn {_os, os_versions} -> os_versions != [] end)
+      |> Enum.map(fn {os, _os_versions} -> os end)
+      |> Enum.sort()
+
+    socket =
+      socket
+      |> assign(
+        builds: builds,
+        oses: oses,
+        erlang_versions: nil,
+        elixir_builds: nil,
+        kind: "erlang",
+        os: "",
+        os_version: "",
+        erlang: "",
+        elixir_build: "",
+        my_requests: my_requests(socket)
+      )
+
+    socket =
+      if connected?(socket) do
+        start_async(socket, :options, fn -> load_options() end)
+      else
+        socket
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:options, {:ok, {erlang_versions, elixir_builds}}, socket) do
+    {:noreply, assign(socket, erlang_versions: erlang_versions, elixir_builds: elixir_builds)}
+  end
+
+  def handle_async(:options, {:exit, _reason}, socket) do
+    {:noreply, put_flash(socket, :error, "Loading versions failed, reload the page to retry.")}
+  end
+
+  @impl true
+  def handle_event("validate", params, socket) do
+    {:noreply, apply_form(socket, params)}
+  end
+
+  def handle_event("request", params, socket) do
+    socket = apply_form(socket, params)
+    %{kind: kind, os: os, os_version: os_version, erlang: erlang} = socket.assigns
+
+    cond do
+      socket.assigns.erlang_versions == nil ->
+        {:noreply, put_flash(socket, :error, "Versions are still loading, try again shortly.")}
+
+      os == "" or os_version == "" or erlang == "" or
+          (kind == "elixir" and socket.assigns.elixir_build == "") ->
+        {:noreply, put_flash(socket, :error, "Select a value for every field.")}
+
+      true ->
+        {:noreply, submit(socket)}
+    end
+  end
+
+  # Selected values are only kept when they appear in the option lists, which
+  # are derived from real refs and builds and already encode the build rules.
+  # Submitted values are therefore valid by construction, also when the params
+  # bypass the rendered dropdowns.
+  defp apply_form(socket, params) do
+    kind = if params["kind"] in ~w(erlang elixir), do: params["kind"], else: "erlang"
+    os = keep_member(params["os"], socket.assigns.oses)
+    os_version = keep_member(params["os_version"], Map.get(socket.assigns.builds, os, []))
+
+    elixir_build =
+      if kind == "elixir" do
+        keep_member(params["elixir_build"], elixir_build_options(socket.assigns.elixir_builds))
+      else
+        ""
+      end
+
+    socket =
+      assign(socket, kind: kind, os: os, os_version: os_version, elixir_build: elixir_build)
+
+    assign(socket, erlang: keep_member(params["erlang"], erlang_options(socket.assigns)))
+  end
+
+  defp keep_member(value, options) do
+    if value in options, do: value, else: ""
+  end
+
+  defp submit(socket) do
+    attrs = %{
+      username: socket.assigns.current_user["username"],
+      kind: socket.assigns.kind,
+      elixir: selected_elixir(socket.assigns),
+      erlang: socket.assigns.erlang,
+      os: socket.assigns.os,
+      os_version: socket.assigns.os_version
+    }
+
+    case BuildRequests.submit(attrs) do
+      {:ok, %BuildRequest{}} ->
+        socket
+        |> assign(my_requests: my_requests(socket))
+        |> put_flash(:info, "Build queued, follow the progress on the jobs dashboard.")
+
+      {:ok, :already_built} ->
+        put_flash(socket, :info, "This image is already built, find it under Docker tags.")
+
+      {:error, :rate_limited} ->
+        put_flash(
+          socket,
+          :error,
+          "You reached the limit of #{BuildRequests.hourly_build_limit()} requested builds " <>
+            "per hour, try again later."
+        )
+
+      {:error, :invalid_combo} ->
+        put_flash(socket, :error, "This combination is not supported by the build rules.")
+    end
+  end
+
+  defp my_requests(socket) do
+    BuildRequests.recent_for_user(socket.assigns.current_user["username"])
+  end
+
+  defp load_options() do
+    erlang_versions =
+      Bob.Cache.fetch(:erlang_versions, @options_ttl, &DockerChecker.erlang_versions/0)
+
+    elixir_builds = Bob.Cache.fetch(:elixir_builds, @options_ttl, &DockerChecker.elixir_builds/0)
+
+    {erlang_versions, elixir_builds}
+  end
+
+  defp erlang_options(%{erlang_versions: nil}), do: []
+  defp erlang_options(%{os: ""}), do: []
+  defp erlang_options(%{os_version: ""}), do: []
+
+  defp erlang_options(assigns) do
+    %{erlang_versions: versions, os: os, os_version: os_version} = assigns
+
+    case {assigns.kind, decode_elixir_build(assigns.elixir_build)} do
+      {"elixir", {elixir, otp_major}} ->
+        Enum.filter(
+          versions,
+          &DockerChecker.valid_elixir_build?(elixir, otp_major, &1, os, os_version)
+        )
+
+      _other ->
+        Enum.filter(versions, &DockerChecker.valid_erlang_build?(&1, os, os_version))
+    end
+  end
+
+  defp elixir_build_options(nil), do: []
+
+  defp elixir_build_options(elixir_builds) do
+    Enum.map(elixir_builds, fn {"v" <> elixir, otp_major} -> "#{elixir}-otp-#{otp_major}" end)
+  end
+
+  defp decode_elixir_build(""), do: nil
+
+  defp decode_elixir_build(elixir_build) do
+    [elixir, otp_major] = String.split(elixir_build, "-otp-")
+    {elixir, otp_major}
+  end
+
+  defp selected_elixir(%{kind: "elixir", elixir_build: elixir_build}) do
+    {elixir, _otp_major} = decode_elixir_build(elixir_build)
+    elixir
+  end
+
+  defp selected_elixir(_assigns), do: nil
+
+  # The erlang base image gets built first when it is missing; surface that so
+  # users know why their elixir tag appears only after a later cycle.
+  defp staged_notice?(assigns) do
+    assigns.kind == "elixir" and assigns.erlang != "" and assigns.os_version != "" and
+      not erlang_base_present?(assigns)
+  end
+
+  defp erlang_base_present?(assigns) do
+    tag = "#{assigns.erlang}-#{assigns.os}-#{assigns.os_version}"
+
+    Enum.all?(DockerChecker.archs(), fn arch ->
+      "hexpm/erlang-#{arch}"
+      |> Bob.Artifacts.docker_tags_present([tag])
+      |> MapSet.member?(tag)
+    end)
+  end
+
+  defp fmt(datetime), do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M:%S")
+
+  defp target(%{kind: "erlang"} = request) do
+    "#{request.erlang}-#{request.os}-#{request.os_version}"
+  end
+
+  defp target(%{kind: "elixir"} = request) do
+    "#{request.elixir}-erlang-#{request.erlang}-#{request.os}-#{request.os_version}"
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="fade-in">
+      <div class="page-head">
+        <div class="page-head__main">
+          <h1>Request a build</h1>
+        </div>
+      </div>
+
+      <section class="sec">
+        <p class="req-intro">
+          Bob automatically builds Docker images for the latest patch release of every
+          Erlang and Elixir version. Need an older patch version? Request it here and it
+          is built for both architectures, including the multi-arch manifest.
+        </p>
+
+        <form phx-change="validate" phx-submit="request" class="filter-bar filter-bar--wrap">
+          <.form_select name="kind" label="image" value={@kind} options={~w(erlang elixir)} />
+          <.form_select name="os" label="os" value={@os} options={@oses} />
+          <.form_select
+            name="os_version"
+            label="os version"
+            value={@os_version}
+            options={Map.get(@builds, @os, [])}
+            disabled={@os == ""}
+          />
+          <.form_select
+            :if={@kind == "elixir"}
+            name="elixir_build"
+            label="elixir"
+            value={@elixir_build}
+            options={elixir_build_options(@elixir_builds)}
+            disabled={@elixir_builds == nil}
+          />
+          <.form_select
+            name="erlang"
+            label="erlang"
+            value={@erlang}
+            options={erlang_options(assigns)}
+            disabled={@erlang_versions == nil or @os_version == ""}
+          />
+          <button class="pg-btn" type="submit">Request build</button>
+        </form>
+
+        <div :if={@erlang_versions == nil} class="empty-mini">Loading versions...</div>
+
+        <div :if={@erlang_versions != nil && staged_notice?(assigns)} class="empty-mini">
+          The Erlang base image for this combination does not exist yet, so it is built
+          first and the Elixir image follows automatically afterwards.
+        </div>
+      </section>
+
+      <section :if={@my_requests != []} class="sec">
+        <h2 class="req-heading">Your recent requests</h2>
+
+        <.table rows={@my_requests} class="jt--req">
+          <:col :let={request} label="image">
+            <%= request.kind %>
+          </:col>
+          <:col :let={request} label="tag">
+            <code class="dk-tag-code" title={target(request)}><%= target(request) %></code>
+          </:col>
+          <:col :let={request} label="state">
+            <%= request.state %>
+          </:col>
+          <:col :let={request} label="requested">
+            <span class="c-time"><%= fmt(request.inserted_at) %></span>
+          </:col>
+        </.table>
+      </section>
+    </div>
+    """
+  end
+
+  attr(:name, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:value, :string, default: "")
+  attr(:options, :list, required: true)
+  attr(:disabled, :boolean, default: false)
+
+  defp form_select(assigns) do
+    ~H"""
+    <label class={["fsel", @disabled && "fsel--off"]}>
+      <span class="fsel__label"><%= @label %>:</span>
+      <select name={@name} disabled={@disabled}>
+        <option value="">choose</option>
+        <option :for={option <- @options} value={option} selected={option == @value}>
+          <%= option %>
+        </option>
+      </select>
+      <.icon name="chevD" size={13} />
+    </label>
+    """
+  end
+end

--- a/lib/bob_web/router.ex
+++ b/lib/bob_web/router.ex
@@ -36,4 +36,12 @@ defmodule BobWeb.Router do
       live("/docker", DockerTagsLive)
     end
   end
+
+  scope "/", BobWeb do
+    pipe_through([:browser, :require_authenticated_user])
+
+    live_session :authenticated, on_mount: [{BobWeb.UserAuth, :ensure_authenticated}] do
+      live("/request", RequestLive)
+    end
+  end
 end

--- a/lib/bob_web/router.ex
+++ b/lib/bob_web/router.ex
@@ -1,6 +1,8 @@
 defmodule BobWeb.Router do
   use BobWeb, :router
 
+  import BobWeb.UserAuth
+
   pipeline :browser do
     plug(:accepts, ["html"])
     plug(:fetch_session)
@@ -8,6 +10,7 @@ defmodule BobWeb.Router do
     plug(:put_root_layout, html: {BobWeb.Layouts, :root})
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
+    plug(:fetch_current_user)
   end
 
   scope "/api", BobWeb do
@@ -23,8 +26,14 @@ defmodule BobWeb.Router do
   scope "/", BobWeb do
     pipe_through(:browser)
 
-    live("/", JobsLive)
-    live("/artifacts", ArtifactsLive)
-    live("/docker", DockerTagsLive)
+    get("/oauth/login", OAuthController, :login)
+    get("/oauth/callback", OAuthController, :callback)
+    post("/oauth/logout", OAuthController, :logout)
+
+    live_session :default, on_mount: [{BobWeb.UserAuth, :mount_current_user}] do
+      live("/", JobsLive)
+      live("/artifacts", ArtifactsLive)
+      live("/docker", DockerTagsLive)
+    end
   end
 end

--- a/lib/bob_web/user_auth.ex
+++ b/lib/bob_web/user_auth.ex
@@ -1,0 +1,115 @@
+defmodule BobWeb.UserAuth do
+  use BobWeb, :verified_routes
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  require Logger
+
+  # Refresh access tokens this close to expiry so they don't expire mid-request.
+  @token_refresh_buffer 5 * 60
+
+  def fetch_current_user(conn, _opts) do
+    case get_session(conn, "current_user") do
+      nil ->
+        assign(conn, :current_user, nil)
+
+      user ->
+        if token_needs_refresh?(conn) do
+          refresh_tokens(conn, user)
+        else
+          assign(conn, :current_user, user)
+        end
+    end
+  end
+
+  def require_authenticated_user(conn, _opts) do
+    if conn.assigns[:current_user] do
+      conn
+    else
+      conn
+      |> put_session("oauth_return_to", current_path(conn))
+      |> redirect(to: ~p"/oauth/login")
+      |> halt()
+    end
+  end
+
+  def on_mount(:mount_current_user, _params, session, socket) do
+    {:cont, Phoenix.Component.assign(socket, :current_user, session["current_user"])}
+  end
+
+  def on_mount(:ensure_authenticated, _params, session, socket) do
+    case session["current_user"] do
+      nil ->
+        {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/oauth/login")}
+
+      user ->
+        {:cont, Phoenix.Component.assign(socket, :current_user, user)}
+    end
+  end
+
+  def log_in_user(conn, user, tokens) do
+    conn
+    |> configure_session(renew: true)
+    |> put_session("current_user", user)
+    |> store_tokens(tokens)
+    |> assign(:current_user, user)
+  end
+
+  def log_out_user(conn) do
+    conn
+    |> configure_session(drop: true)
+    |> assign(:current_user, nil)
+  end
+
+  def safe_return_path("/" <> rest = path) do
+    if String.starts_with?(rest, "/") do
+      "/"
+    else
+      path
+    end
+  end
+
+  def safe_return_path(_other), do: "/"
+
+  defp store_tokens(conn, tokens) do
+    expires_at = System.system_time(:second) + tokens["expires_in"]
+    refresh_token = tokens["refresh_token"] || get_session(conn, "refresh_token")
+
+    conn
+    |> put_session("access_token", tokens["access_token"])
+    |> put_session("refresh_token", refresh_token)
+    |> put_session("token_expires_at", expires_at)
+  end
+
+  defp token_needs_refresh?(conn) do
+    case get_session(conn, "token_expires_at") do
+      nil -> true
+      expires_at -> expires_at - System.system_time(:second) <= @token_refresh_buffer
+    end
+  end
+
+  defp refresh_tokens(conn, user) do
+    with refresh_token when is_binary(refresh_token) <- get_session(conn, "refresh_token"),
+         {:ok, tokens} <- Bob.Hexpm.refresh_token(refresh_token) do
+      conn
+      |> store_tokens(tokens)
+      |> assign(:current_user, user)
+    else
+      error ->
+        Logger.warning("OAUTH token refresh failed: #{inspect(error)}")
+
+        conn
+        |> clear_auth_session()
+        |> assign(:current_user, nil)
+    end
+  end
+
+  defp clear_auth_session(conn) do
+    Enum.reduce(
+      ["current_user", "access_token", "refresh_token", "token_expires_at"],
+      conn,
+      &delete_session(&2, &1)
+    )
+  end
+end

--- a/lib/bob_web/user_auth.ex
+++ b/lib/bob_web/user_auth.ex
@@ -62,8 +62,10 @@ defmodule BobWeb.UserAuth do
     |> assign(:current_user, nil)
   end
 
+  # A leading "//" or "/\" is a protocol-relative URL that browsers send
+  # off-site, so only plain in-app paths are allowed through.
   def safe_return_path("/" <> rest = path) do
-    if String.starts_with?(rest, "/") do
+    if String.starts_with?(rest, "/") or String.starts_with?(rest, "\\") do
       "/"
     else
       path
@@ -72,12 +74,15 @@ defmodule BobWeb.UserAuth do
 
   def safe_return_path(_other), do: "/"
 
+  # Only the refresh token is persisted: it lets us refresh near expiry and
+  # revoke on logout, and a failed refresh is how we notice the user revoked
+  # access on hex.pm. The access token is never reused after login — we only
+  # need the username — so storing it would be cookie surface for no purpose.
   defp store_tokens(conn, tokens) do
     expires_at = System.system_time(:second) + tokens["expires_in"]
     refresh_token = tokens["refresh_token"] || get_session(conn, "refresh_token")
 
     conn
-    |> put_session("access_token", tokens["access_token"])
     |> put_session("refresh_token", refresh_token)
     |> put_session("token_expires_at", expires_at)
   end
@@ -107,7 +112,7 @@ defmodule BobWeb.UserAuth do
 
   defp clear_auth_session(conn) do
     Enum.reduce(
-      ["current_user", "access_token", "refresh_token", "token_expires_at"],
+      ["current_user", "refresh_token", "token_expires_at"],
       conn,
       &delete_session(&2, &1)
     )

--- a/priv/repo/migrations/20260612170000_create_build_requests.exs
+++ b/priv/repo/migrations/20260612170000_create_build_requests.exs
@@ -1,0 +1,20 @@
+defmodule Bob.Repo.Migrations.CreateBuildRequests do
+  use Ecto.Migration
+
+  def change do
+    create table(:build_requests) do
+      add :username, :string, null: false
+      add :kind, :string, null: false
+      add :elixir, :string
+      add :erlang, :string, null: false
+      add :os, :string, null: false
+      add :os_version, :string, null: false
+      add :builds_count, :integer, null: false
+      add :state, :string, null: false, default: "pending"
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:build_requests, [:username, :inserted_at])
+    create index(:build_requests, [:state], where: "state = 'pending'")
+  end
+end

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -641,6 +641,41 @@ defmodule Bob.ArtifactsTest do
 
       assert Artifacts.base_image_tags("library/alpine") == ["3.23.5"]
     end
+
+    test "keeps inserted_at for surviving tags and stamps only new ones" do
+      old = DateTime.add(DateTime.utc_now(), -90, :day)
+
+      %BaseImageTag{repo: "library/alpine", tag: "3.23.5"}
+      |> Repo.insert!()
+      |> Ecto.Changeset.change(inserted_at: old)
+      |> Repo.update!()
+
+      Artifacts.replace_base_image_tags("library/alpine", ["3.23.5", "3.24.0"])
+
+      by_tag =
+        from(b in BaseImageTag, where: b.repo == "library/alpine")
+        |> Repo.all()
+        |> Map.new(&{&1.tag, &1.inserted_at})
+
+      assert DateTime.compare(by_tag["3.23.5"], old) == :eq
+      assert DateTime.diff(DateTime.utc_now(), by_tag["3.24.0"]) < 60
+    end
+  end
+
+  describe "recent_base_image_versions/1" do
+    test "returns {os, tag} for base images first seen since the cutoff" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250601"})
+
+      %BaseImageTag{repo: "library/debian", tag: "bookworm-20240101"}
+      |> Repo.insert!()
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -90, :day))
+      |> Repo.update!()
+
+      cutoff = DateTime.add(DateTime.utc_now(), -30, :day)
+
+      assert Artifacts.recent_base_image_versions(cutoff) ==
+               MapSet.new([{"ubuntu", "noble-20250601"}])
+    end
   end
 
   describe "search" do

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -676,6 +676,16 @@ defmodule Bob.ArtifactsTest do
       assert Artifacts.recent_base_image_versions(cutoff) ==
                MapSet.new([{"ubuntu", "noble-20250601"}])
     end
+
+    test "skips repos without a library/ prefix instead of crashing" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250601"})
+      Repo.insert!(%BaseImageTag{repo: "hexpm/custom", tag: "weird"})
+
+      cutoff = DateTime.add(DateTime.utc_now(), -30, :day)
+
+      assert Artifacts.recent_base_image_versions(cutoff) ==
+               MapSet.new([{"ubuntu", "noble-20250601"}])
+    end
   end
 
   describe "search" do

--- a/test/bob/build_requests_test.exs
+++ b/test/bob/build_requests_test.exs
@@ -1,0 +1,157 @@
+defmodule Bob.BuildRequestsTest do
+  use Bob.DataCase
+
+  alias Bob.Artifacts
+  alias Bob.BuildRequests
+  alias Bob.BuildRequests.BuildRequest
+  alias Bob.Queue.Job
+
+  @erlang_attrs %{
+    username: "eric",
+    kind: "erlang",
+    erlang: "27.0",
+    os: "ubuntu",
+    os_version: "noble-20250101"
+  }
+
+  @elixir_attrs %{
+    username: "eric",
+    kind: "elixir",
+    elixir: "1.18.0",
+    erlang: "27.0",
+    os: "ubuntu",
+    os_version: "noble-20250101"
+  }
+
+  describe "submit/1 with an erlang request" do
+    test "enqueues a build per missing arch and records the request" do
+      assert {:ok, %BuildRequest{} = request} = submit(@erlang_attrs)
+
+      assert request.builds_count == 2
+      assert request.state == "pending"
+
+      jobs = Repo.all(Job) |> Enum.map(&{&1.module_key, &1.args}) |> Enum.sort()
+
+      assert jobs ==
+               Enum.sort([
+                 {{Bob.Job.BuildDockerErlang, "amd64"}, ["27.0", "ubuntu", "noble-20250101"]},
+                 {{Bob.Job.BuildDockerErlang, "arm64"}, ["27.0", "ubuntu", "noble-20250101"]}
+               ])
+    end
+
+    test "enqueues only the missing arch" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      assert {:ok, %BuildRequest{builds_count: 1}} = submit(@erlang_attrs)
+
+      assert [%Job{module_key: {Bob.Job.BuildDockerErlang, "arm64"}}] = Repo.all(Job)
+    end
+
+    test "reports already built tags without recording a request" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      assert BuildRequests.submit(@erlang_attrs) == {:ok, :already_built}
+      assert Repo.all(Job) == []
+      assert Repo.all(BuildRequest) == []
+    end
+
+    test "rejects combinations the build rules reject" do
+      attrs = %{@erlang_attrs | erlang: "24.1"}
+
+      assert BuildRequests.submit(attrs) == {:error, :invalid_combo}
+      assert Repo.all(Job) == []
+      assert Repo.all(BuildRequest) == []
+    end
+  end
+
+  describe "submit/1 with an elixir request" do
+    test "enqueues the elixir builds when the erlang base exists" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      assert {:ok, %BuildRequest{builds_count: 2}} = submit(@elixir_attrs)
+
+      jobs = Repo.all(Job) |> Enum.map(&{&1.module_key, &1.args}) |> Enum.sort()
+
+      assert jobs ==
+               Enum.sort([
+                 {{Bob.Job.BuildDockerElixir, "amd64"},
+                  ["1.18.0", "27.0", "ubuntu", "noble-20250101"]},
+                 {{Bob.Job.BuildDockerElixir, "arm64"},
+                  ["1.18.0", "27.0", "ubuntu", "noble-20250101"]}
+               ])
+    end
+
+    test "enqueues the erlang base first when it is missing" do
+      assert {:ok, %BuildRequest{builds_count: 4}} = submit(@elixir_attrs)
+
+      jobs = Repo.all(Job) |> Enum.map(& &1.module_key) |> Enum.sort()
+
+      assert jobs ==
+               Enum.sort([
+                 {Bob.Job.BuildDockerErlang, "amd64"},
+                 {Bob.Job.BuildDockerErlang, "arm64"}
+               ])
+    end
+
+    test "rejects erlang versions elixir is never built for" do
+      attrs = %{@elixir_attrs | elixir: "1.14.5", erlang: "26.0-rc1"}
+
+      assert BuildRequests.submit(attrs) == {:error, :invalid_combo}
+    end
+
+    test "rejects a missing elixir version" do
+      attrs = %{@elixir_attrs | elixir: nil}
+
+      assert BuildRequests.submit(attrs) == {:error, :invalid_combo}
+    end
+  end
+
+  describe "submit/1 rate limiting" do
+    test "rejects requests over the hourly build limit" do
+      {:ok, _request} =
+        BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 9))
+
+      assert BuildRequests.submit(%{@erlang_attrs | erlang: "28.0"}) == {:error, :rate_limited}
+      assert Repo.all(Job) == []
+    end
+
+    test "ignores requests older than an hour" do
+      {:ok, request} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 10))
+
+      request
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -2, :hour))
+      |> Repo.update!()
+
+      assert {:ok, %BuildRequest{}} = submit(%{@erlang_attrs | erlang: "28.0"})
+    end
+
+    test "counts builds across requests within the hour" do
+      {:ok, _request} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 8))
+
+      assert {:ok, %BuildRequest{builds_count: 2}} = submit(%{@erlang_attrs | erlang: "28.0"})
+      assert BuildRequests.submit(%{@erlang_attrs | erlang: "28.1"}) == {:error, :rate_limited}
+    end
+  end
+
+  describe "builds_count_for_user_since/2" do
+    test "sums only the given user's requests" do
+      {:ok, _} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 2))
+      {:ok, _} = BuildRequests.create(Map.put(@elixir_attrs, :builds_count, 4))
+
+      {:ok, _} =
+        BuildRequests.create(%{@erlang_attrs | username: "jose"} |> Map.put(:builds_count, 2))
+
+      hour_ago = DateTime.add(DateTime.utc_now(), -1, :hour)
+
+      assert BuildRequests.builds_count_for_user_since("eric", hour_ago) == 6
+      assert BuildRequests.builds_count_for_user_since("jose", hour_ago) == 2
+      assert BuildRequests.builds_count_for_user_since("nobody", hour_ago) == 0
+    end
+  end
+
+  defp submit(attrs) do
+    BuildRequests.submit(attrs)
+  end
+end

--- a/test/bob/build_requests_test.exs
+++ b/test/bob/build_requests_test.exs
@@ -151,6 +151,42 @@ defmodule Bob.BuildRequestsTest do
     end
   end
 
+  describe "pending/1" do
+    test "returns a bounded oldest-first list of pending requests" do
+      {:ok, oldest} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 2))
+      {:ok, completed} = BuildRequests.create(Map.put(@elixir_attrs, :builds_count, 4))
+
+      {:ok, newest} =
+        BuildRequests.create(
+          %{@erlang_attrs | username: "jose", erlang: "28.0"}
+          |> Map.put(:builds_count, 2)
+        )
+
+      oldest
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -3, :hour))
+      |> Repo.update!()
+
+      completed
+      |> Ecto.Changeset.change(
+        state: "completed",
+        inserted_at: DateTime.add(DateTime.utc_now(), -2, :hour)
+      )
+      |> Repo.update!()
+
+      newest
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -1, :hour))
+      |> Repo.update!()
+
+      assert [%BuildRequest{id: oldest_id}, %BuildRequest{id: newest_id}] =
+               BuildRequests.pending(10)
+
+      assert [oldest_id, newest_id] == [oldest.id, newest.id]
+
+      assert [%BuildRequest{id: oldest_id}] = BuildRequests.pending(1)
+      assert oldest_id == oldest.id
+    end
+  end
+
   defp submit(attrs) do
     BuildRequests.submit(attrs)
   end

--- a/test/bob/build_requests_test.exs
+++ b/test/bob/build_requests_test.exs
@@ -50,10 +50,21 @@ defmodule Bob.BuildRequestsTest do
     test "reports already built tags without recording a request" do
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
 
       assert BuildRequests.submit(@erlang_attrs) == {:ok, :already_built}
       assert Repo.all(Job) == []
       assert Repo.all(BuildRequest) == []
+    end
+
+    test "enqueues only the manifest when the arch images already exist" do
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      assert {:ok, %BuildRequest{}} = submit(@erlang_attrs)
+
+      assert [%Job{module_key: Bob.Job.DockerManifest, args: args}] = Repo.all(Job)
+      assert args == ["erlang", {"27.0", "ubuntu", "noble-20250101"}]
     end
 
     test "rejects combinations the build rules reject" do

--- a/test/bob/build_requests_test.exs
+++ b/test/bob/build_requests_test.exs
@@ -187,6 +187,68 @@ defmodule Bob.BuildRequestsTest do
     end
   end
 
+  describe "recent/2 and count/0" do
+    test "returns all requests newest-first, regardless of user or state" do
+      {:ok, oldest} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 2))
+
+      {:ok, newest} =
+        BuildRequests.create(%{@elixir_attrs | username: "jose"} |> Map.put(:builds_count, 4))
+
+      oldest
+      |> Ecto.Changeset.change(
+        state: "completed",
+        inserted_at: DateTime.add(DateTime.utc_now(), -1, :hour)
+      )
+      |> Repo.update!()
+
+      assert [%BuildRequest{id: first}, %BuildRequest{id: second}] =
+               BuildRequests.recent(50, 0)
+
+      assert [first, second] == [newest.id, oldest.id]
+      assert BuildRequests.count() == 2
+    end
+
+    test "paginates with limit and offset" do
+      for n <- 1..3 do
+        {:ok, request} = BuildRequests.create(Map.put(@erlang_attrs, :builds_count, 2))
+
+        request
+        |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -n, :minute))
+        |> Repo.update!()
+      end
+
+      assert [%BuildRequest{}, %BuildRequest{}] = BuildRequests.recent(2, 0)
+      assert [%BuildRequest{}] = BuildRequests.recent(2, 2)
+      assert BuildRequests.recent(2, 3) == []
+    end
+  end
+
+  describe "prune/1" do
+    test "deletes finished requests older than the cutoff and keeps the rest" do
+      _old_completed = insert_aged(%{state: "completed"}, -100)
+      _old_expired = insert_aged(%{state: "expired"}, -100)
+      old_pending = insert_aged(%{state: "pending"}, -100)
+      recent_completed = insert_aged(%{state: "completed"}, -1)
+
+      assert BuildRequests.prune(90 * 24 * 60 * 60) == 2
+
+      ids = Repo.all(BuildRequest) |> Enum.map(& &1.id) |> Enum.sort()
+      assert ids == Enum.sort([old_pending.id, recent_completed.id])
+    end
+  end
+
+  defp insert_aged(attrs, days) do
+    {:ok, request} =
+      BuildRequests.create(Map.merge(@erlang_attrs, Map.put(attrs, :builds_count, 2)))
+
+    request
+    |> Ecto.Changeset.change(
+      state: attrs.state,
+      inserted_at: DateTime.add(DateTime.utc_now(), days, :day)
+    )
+    |> Repo.update!()
+  end
+
   defp submit(attrs) do
     BuildRequests.submit(attrs)
   end

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -8,10 +8,7 @@ defmodule Bob.Job.DockerCheckerTest do
   alias Bob.Artifacts.BaseImageTag
   alias Bob.Queue.Job
 
-  @builds_txt_url "https://s3.amazonaws.com/s3.hex.pm/builds/elixir/builds.txt"
-
   setup do
-    Bob.FakeHttpClient.reset()
     Bob.FakeGitHub.reset()
     :ok
   end
@@ -73,6 +70,26 @@ defmodule Bob.Job.DockerCheckerTest do
       builds = [{"v1.18", "27"}, {"v1.18.4", "27"}]
 
       assert DockerChecker.latest_elixir_builds(builds) == [{"v1.18.4", "27"}]
+    end
+  end
+
+  describe "elixir_builds/0" do
+    test "uses OTP-specific zip assets from GitHub releases" do
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+        release("v1.18.0", ["27", "26", "exe-25"]),
+        release("v1.18.4", ["27", "26"]),
+        release("v1.20-latest", ["29"]),
+        release("v1.9.4", ["21"]),
+        release("v1.11.0-rc.0", ["23"])
+      ])
+
+      assert DockerChecker.elixir_builds() ==
+               [
+                 {"v1.18.4", "27"},
+                 {"v1.18.4", "26"},
+                 {"v1.18.0", "27"},
+                 {"v1.18.0", "26"}
+               ]
     end
   end
 
@@ -194,16 +211,10 @@ defmodule Bob.Job.DockerCheckerTest do
     test "crosses current-os-version erlang tags with compatible elixir builds" do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
       Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [release("v1.18.0", ["27", "26"])])
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       # An erlang tag on a base image that is no longer current contributes nothing.
       Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20240101", ["arm64"])
-
-      Bob.FakeHttpClient.stub(
-        :get,
-        @builds_txt_url,
-        200,
-        "v1.18.0-otp-27 abc123\nv1.18.0-otp-26 def456\n"
-      )
 
       assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
                [{"1.18.0", "27.0", "ubuntu", "noble-20250101", "amd64"}]
@@ -212,12 +223,11 @@ defmodule Bob.Job.DockerCheckerTest do
     test "expands only over the latest patch per erlang minor" do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
       Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-27.0.1", "sha2"}])
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [release("v1.18.0", ["27"])])
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0.1-ubuntu-noble-20250101", ["amd64"])
       # An erlang tag that is not the latest patch, e.g. built on user request,
       # contributes nothing.
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
-
-      Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
 
       assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
                [{"1.18.0", "27.0.1", "ubuntu", "noble-20250101", "amd64"}]
@@ -226,14 +236,13 @@ defmodule Bob.Job.DockerCheckerTest do
     test "expands only over the latest elixir build per minor and otp major" do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
       Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
-      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
 
-      Bob.FakeHttpClient.stub(
-        :get,
-        @builds_txt_url,
-        200,
-        "v1.18.0-otp-27 abc123\nv1.18.4-otp-27 def456\n"
-      )
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+        release("v1.18.0", ["27"]),
+        release("v1.18.4", ["27"])
+      ])
+
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
 
       assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
                [{"1.18.4", "27.0", "ubuntu", "noble-20250101", "amd64"}]
@@ -244,8 +253,8 @@ defmodule Bob.Job.DockerCheckerTest do
     setup do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
       Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [release("v1.18.0", ["27"])])
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
-      Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
       :ok
     end
 
@@ -377,6 +386,16 @@ defmodule Bob.Job.DockerCheckerTest do
       {:ok, request} = Bob.BuildRequests.create(attrs)
       request
     end
+  end
+
+  defp release(tag_name, otp_majors) do
+    assets =
+      Enum.map(otp_majors, fn
+        "exe-" <> otp -> %{"name" => "elixir-otp-#{otp}.exe"}
+        otp -> %{"name" => "elixir-otp-#{otp}.zip"}
+      end)
+
+    %{"tag_name" => tag_name, "assets" => assets}
   end
 
   describe "manifest/0" do

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -269,6 +269,116 @@ defmodule Bob.Job.DockerCheckerTest do
     end
   end
 
+  describe "requests/0" do
+    setup do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      :ok
+    end
+
+    test "enqueues missing builds and keeps the request pending" do
+      request = insert_request(kind: "erlang", erlang: "27.0")
+
+      DockerChecker.requests()
+
+      assert Enum.count(Repo.all(Job)) == 2
+      assert Repo.reload!(request).state == "pending"
+    end
+
+    test "completes an erlang request once both archs are built" do
+      request = insert_request(kind: "erlang", erlang: "27.0")
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+      DockerChecker.requests()
+
+      assert Repo.all(Job) == []
+      assert Repo.reload!(request).state == "completed"
+    end
+
+    test "stages an elixir request through the erlang base build" do
+      request = insert_request(kind: "elixir", elixir: "1.18.0", erlang: "27.0")
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      DockerChecker.requests()
+
+      jobs = Repo.all(Job) |> Enum.map(&{&1.module_key, &1.args}) |> Enum.sort()
+
+      assert jobs ==
+               Enum.sort([
+                 {{Bob.Job.BuildDockerElixir, "amd64"},
+                  ["1.18.0", "27.0", "ubuntu", "noble-20250101"]},
+                 {{Bob.Job.BuildDockerErlang, "arm64"}, ["27.0", "ubuntu", "noble-20250101"]}
+               ])
+
+      assert Repo.reload!(request).state == "pending"
+    end
+
+    test "completes an elixir request once both archs are built" do
+      request = insert_request(kind: "elixir", elixir: "1.18.0", erlang: "27.0")
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-arm64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["arm64"]
+      )
+
+      DockerChecker.requests()
+
+      assert Repo.all(Job) == []
+      assert Repo.reload!(request).state == "completed"
+    end
+
+    test "expires requests whose os_version is no longer current" do
+      request = insert_request(kind: "erlang", erlang: "27.0", os_version: "noble-20240101")
+
+      DockerChecker.requests()
+
+      assert Repo.all(Job) == []
+      assert Repo.reload!(request).state == "expired"
+    end
+
+    test "expires requests that never completed within the ttl" do
+      request = insert_request(kind: "erlang", erlang: "27.0")
+
+      request
+      |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -15, :day))
+      |> Repo.update!()
+
+      DockerChecker.requests()
+
+      assert Repo.all(Job) == []
+      assert Repo.reload!(request).state == "expired"
+    end
+
+    test "does not duplicate jobs already queued" do
+      insert_request(kind: "erlang", erlang: "27.0")
+
+      DockerChecker.requests()
+      DockerChecker.requests()
+
+      assert Enum.count(Repo.all(Job)) == 2
+    end
+
+    defp insert_request(attrs) do
+      attrs =
+        Enum.into(attrs, %{
+          username: "eric",
+          os: "ubuntu",
+          os_version: "noble-20250101",
+          builds_count: 2
+        })
+
+      {:ok, request} = Bob.BuildRequests.create(attrs)
+      request
+    end
+  end
+
   describe "manifest/0" do
     test "enqueues manifest jobs for per-arch tags missing from the manifest repo" do
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -278,6 +278,68 @@ defmodule Bob.Job.DockerCheckerTest do
     end
   end
 
+  describe "build freshness" do
+    test "erlang/0 skips combos whose components were all released long ago" do
+      insert_base_image("library/ubuntu", "noble-20240101", 60)
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0.1", "sha"}])
+      Bob.FakeGitHub.stub_releases("erlang/otp", [otp_release("OTP-27.0.1", days_ago_iso(60))])
+
+      DockerChecker.erlang()
+
+      assert Repo.all(Job) == []
+    end
+
+    test "erlang/0 builds when the OTP version was released recently" do
+      insert_base_image("library/ubuntu", "noble-20240101", 60)
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0.1", "sha"}])
+      Bob.FakeGitHub.stub_releases("erlang/otp", [otp_release("OTP-27.0.1", days_ago_iso(2))])
+
+      DockerChecker.erlang()
+
+      assert Enum.count(Repo.all(Job)) == 2
+    end
+
+    test "erlang/0 builds when the base image is recent even for an old OTP" do
+      insert_base_image("library/ubuntu", "noble-20250601", 2)
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0.1", "sha"}])
+      Bob.FakeGitHub.stub_releases("erlang/otp", [otp_release("OTP-27.0.1", days_ago_iso(400))])
+
+      DockerChecker.erlang()
+
+      assert Enum.count(Repo.all(Job)) == 2
+    end
+
+    test "elixir/0 builds when the Elixir version was released recently" do
+      insert_base_image("library/ubuntu", "noble-20240101", 60)
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
+      Bob.FakeGitHub.stub_releases("erlang/otp", [otp_release("OTP-27.0", days_ago_iso(400))])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20240101", ["amd64"])
+
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+        release("v1.18.0", ["27"], days_ago_iso(2))
+      ])
+
+      DockerChecker.elixir()
+
+      assert [%Job{module_key: {Bob.Job.BuildDockerElixir, "amd64"}}] = Repo.all(Job)
+    end
+
+    test "elixir/0 skips when every component is old" do
+      insert_base_image("library/ubuntu", "noble-20240101", 60)
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
+      Bob.FakeGitHub.stub_releases("erlang/otp", [otp_release("OTP-27.0", days_ago_iso(400))])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20240101", ["amd64"])
+
+      Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+        release("v1.18.0", ["27"], days_ago_iso(400))
+      ])
+
+      DockerChecker.elixir()
+
+      assert Repo.all(Job) == []
+    end
+  end
+
   describe "requests/0" do
     setup do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
@@ -420,14 +482,31 @@ defmodule Bob.Job.DockerCheckerTest do
     end
   end
 
-  defp release(tag_name, otp_majors) do
+  defp release(tag_name, otp_majors, published_at \\ now_iso()) do
     assets =
       Enum.map(otp_majors, fn
         "exe-" <> otp -> %{"name" => "elixir-otp-#{otp}.exe"}
         otp -> %{"name" => "elixir-otp-#{otp}.zip"}
       end)
 
-    %{"tag_name" => tag_name, "assets" => assets}
+    %{"tag_name" => tag_name, "assets" => assets, "published_at" => published_at}
+  end
+
+  defp otp_release(tag_name, published_at) do
+    %{"tag_name" => tag_name, "published_at" => published_at}
+  end
+
+  defp now_iso(), do: DateTime.utc_now() |> DateTime.to_iso8601()
+
+  defp days_ago_iso(days) do
+    DateTime.utc_now() |> DateTime.add(-days, :day) |> DateTime.to_iso8601()
+  end
+
+  defp insert_base_image(repo, tag, days_old) do
+    %BaseImageTag{repo: repo, tag: tag}
+    |> Repo.insert!()
+    |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -days_old, :day))
+    |> Repo.update!()
   end
 
   describe "manifest/0" do

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -293,15 +293,40 @@ defmodule Bob.Job.DockerCheckerTest do
       assert Repo.reload!(request).state == "pending"
     end
 
-    test "completes an erlang request once both archs are built" do
+    test "enqueues the manifest once the erlang archs are built" do
       request = insert_request(kind: "erlang", erlang: "27.0")
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
 
       DockerChecker.requests()
 
+      assert [%Job{module_key: Bob.Job.DockerManifest, args: args}] = Repo.all(Job)
+      assert args == ["erlang", {"27.0", "ubuntu", "noble-20250101"}]
+      assert Repo.reload!(request).state == "pending"
+    end
+
+    test "completes an erlang request once the manifest spans both archs" do
+      request = insert_request(kind: "erlang", erlang: "27.0")
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
+
+      DockerChecker.requests()
+
       assert Repo.all(Job) == []
       assert Repo.reload!(request).state == "completed"
+    end
+
+    test "keeps an erlang request pending while the manifest covers one arch" do
+      request = insert_request(kind: "erlang", erlang: "27.0")
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      DockerChecker.requests()
+
+      assert [%Job{module_key: Bob.Job.DockerManifest}] = Repo.all(Job)
+      assert Repo.reload!(request).state == "pending"
     end
 
     test "stages an elixir request through the erlang base build" do
@@ -322,25 +347,32 @@ defmodule Bob.Job.DockerCheckerTest do
       assert Repo.reload!(request).state == "pending"
     end
 
-    test "completes an elixir request once both archs are built" do
+    test "completes an elixir request once the manifest spans both archs" do
       request = insert_request(kind: "elixir", elixir: "1.18.0", erlang: "27.0")
+      tag = "1.18.0-erlang-27.0-ubuntu-noble-20250101"
 
-      Artifacts.add_docker_tag(
-        "hexpm/elixir-amd64",
-        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
-        ["amd64"]
-      )
-
-      Artifacts.add_docker_tag(
-        "hexpm/elixir-arm64",
-        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
-        ["arm64"]
-      )
+      Artifacts.add_docker_tag("hexpm/elixir-amd64", tag, ["amd64"])
+      Artifacts.add_docker_tag("hexpm/elixir-arm64", tag, ["arm64"])
+      Artifacts.add_docker_tag("hexpm/elixir", tag, ["amd64", "arm64"])
 
       DockerChecker.requests()
 
       assert Repo.all(Job) == []
       assert Repo.reload!(request).state == "completed"
+    end
+
+    test "enqueues the manifest once the elixir archs are built" do
+      request = insert_request(kind: "elixir", elixir: "1.18.0", erlang: "27.0")
+      tag = "1.18.0-erlang-27.0-ubuntu-noble-20250101"
+
+      Artifacts.add_docker_tag("hexpm/elixir-amd64", tag, ["amd64"])
+      Artifacts.add_docker_tag("hexpm/elixir-arm64", tag, ["arm64"])
+
+      DockerChecker.requests()
+
+      assert [%Job{module_key: Bob.Job.DockerManifest, args: args}] = Repo.all(Job)
+      assert args == ["elixir", {"1.18.0", "27.0", "ubuntu", "noble-20250101"}]
+      assert Repo.reload!(request).state == "pending"
     end
 
     test "expires requests whose os_version is no longer current" do

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -12,7 +12,168 @@ defmodule Bob.Job.DockerCheckerTest do
 
   setup do
     Bob.FakeHttpClient.reset()
+    Bob.FakeGitHub.reset()
     :ok
+  end
+
+  describe "latest_erlang_refs/1" do
+    test "keeps only the newest ref per major.minor line" do
+      refs = ["OTP-26.2", "OTP-26.2.5", "OTP-26.2.5.21", "OTP-26.1.2", "OTP-27.0"]
+
+      assert DockerChecker.latest_erlang_refs(refs) ==
+               ["OTP-27.0", "OTP-26.2.5.21", "OTP-26.1.2"]
+    end
+
+    test "orders multi-component patch versions numerically" do
+      refs = ["OTP-26.2.5.3", "OTP-26.2.5.21"]
+
+      assert DockerChecker.latest_erlang_refs(refs) == ["OTP-26.2.5.21"]
+    end
+
+    test "drops prereleases once a stable release exists in the line" do
+      refs = ["OTP-29.0-rc1", "OTP-29.0-rc3", "OTP-29.0.2"]
+
+      assert DockerChecker.latest_erlang_refs(refs) == ["OTP-29.0.2"]
+    end
+
+    test "keeps the newest prerelease in a line without stable releases" do
+      refs = ["OTP-30.0-rc1", "OTP-30.0-rc2", "OTP-29.0.2"]
+
+      assert DockerChecker.latest_erlang_refs(refs) == ["OTP-30.0-rc2", "OTP-29.0.2"]
+    end
+
+    test "is independent of input order" do
+      refs = ["OTP-26.2.5.21", "OTP-27.0", "OTP-26.2", "OTP-26.1.2", "OTP-26.2.5"]
+
+      assert DockerChecker.latest_erlang_refs(refs) ==
+               ["OTP-27.0", "OTP-26.2.5.21", "OTP-26.1.2"]
+    end
+  end
+
+  describe "latest_elixir_builds/1" do
+    test "keeps only the newest build per elixir minor and otp major" do
+      builds = [
+        {"v1.19.0", "27"},
+        {"v1.19.5", "27"},
+        {"v1.19.5", "28"},
+        {"v1.18.4", "27"}
+      ]
+
+      assert DockerChecker.latest_elixir_builds(builds) ==
+               [{"v1.19.5", "28"}, {"v1.19.5", "27"}, {"v1.18.4", "27"}]
+    end
+
+    test "drops prereleases once a stable release exists in the minor" do
+      builds = [{"v1.19.0-rc.0", "27"}, {"v1.19.5", "27"}]
+
+      assert DockerChecker.latest_elixir_builds(builds) == [{"v1.19.5", "27"}]
+    end
+
+    test "normalizes two-component versions" do
+      builds = [{"v1.18", "27"}, {"v1.18.4", "27"}]
+
+      assert DockerChecker.latest_elixir_builds(builds) == [{"v1.18.4", "27"}]
+    end
+  end
+
+  describe "expected_erlang_tags/0" do
+    test "crosses only the latest patch per minor with current base images" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+
+      Bob.FakeGitHub.stub_refs("erlang/otp", [
+        {"OTP-26.2.5", "sha1"},
+        {"OTP-26.2.5.21", "sha2"},
+        {"OTP-27.0", "sha3"}
+      ])
+
+      assert Enum.sort(DockerChecker.expected_erlang_tags()) ==
+               Enum.sort([
+                 {"26.2.5.21", "ubuntu", "noble-20250101", "amd64"},
+                 {"26.2.5.21", "ubuntu", "noble-20250101", "arm64"},
+                 {"27.0", "ubuntu", "noble-20250101", "amd64"},
+                 {"27.0", "ubuntu", "noble-20250101", "arm64"}
+               ])
+    end
+
+    test "applies the os rules after the latest-patch collapse" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "resolute-20260101"})
+
+      Bob.FakeGitHub.stub_refs("erlang/otp", [
+        {"OTP-25.3.2.21", "sha1"},
+        {"OTP-26.2.5.21", "sha2"}
+      ])
+
+      assert Enum.sort(DockerChecker.expected_erlang_tags()) ==
+               Enum.sort([
+                 {"26.2.5.21", "ubuntu", "resolute-20260101", "amd64"},
+                 {"26.2.5.21", "ubuntu", "resolute-20260101", "arm64"}
+               ])
+    end
+  end
+
+  describe "valid_erlang_build?/3" do
+    test "requires openssl 3 support on ubuntu and debian" do
+      refute DockerChecker.valid_erlang_build?("24.1", "ubuntu", "noble-20250101")
+      assert DockerChecker.valid_erlang_build?("24.2", "ubuntu", "noble-20250101")
+      refute DockerChecker.valid_erlang_build?("24.1", "debian", "bookworm-20250101")
+      assert DockerChecker.valid_erlang_build?("24.2", "debian", "bookworm-20250101")
+    end
+
+    test "requires c23 compatibility on ubuntu resolute" do
+      refute DockerChecker.valid_erlang_build?("25.3.2.21", "ubuntu", "resolute-20260101")
+      refute DockerChecker.valid_erlang_build?("26.0-rc3", "ubuntu", "resolute-20260101")
+      assert DockerChecker.valid_erlang_build?("26.0", "ubuntu", "resolute-20260101")
+    end
+
+    test "applies the alpine rules" do
+      refute DockerChecker.valid_erlang_build?("20.3", "alpine", "3.22.1")
+      refute DockerChecker.valid_erlang_build?("25.3", "alpine", "3.23.5")
+      assert DockerChecker.valid_erlang_build?("26.1", "alpine", "3.23.5")
+    end
+  end
+
+  describe "valid_elixir_build?/5" do
+    test "accepts a compatible combination" do
+      assert DockerChecker.valid_elixir_build?("1.18.0", "27", "27.0", "ubuntu", "noble-20250101")
+    end
+
+    test "rejects an otp major mismatch" do
+      refute DockerChecker.valid_elixir_build?("1.18.0", "26", "27.0", "ubuntu", "noble-20250101")
+    end
+
+    test "rejects erlang versions elixir is never built for" do
+      refute DockerChecker.valid_elixir_build?(
+               "1.14.5",
+               "26",
+               "26.0-rc1",
+               "ubuntu",
+               "noble-20250101"
+             )
+    end
+
+    test "rejects elixir versions below 1.10" do
+      refute DockerChecker.valid_elixir_build?(
+               "1.9.4",
+               "22",
+               "22.3",
+               "debian",
+               "bullseye-20250101"
+             )
+    end
+
+    test "rejects prereleases below 1.12" do
+      refute DockerChecker.valid_elixir_build?(
+               "1.11.0-rc.0",
+               "23",
+               "23.3",
+               "debian",
+               "bullseye-20250101"
+             )
+    end
+
+    test "rejects combinations the erlang rules reject" do
+      refute DockerChecker.valid_elixir_build?("1.18.0", "24", "24.1", "ubuntu", "noble-20250101")
+    end
   end
 
   describe "builds/0" do
@@ -32,6 +193,7 @@ defmodule Bob.Job.DockerCheckerTest do
   describe "expected_elixir_tags/0" do
     test "crosses current-os-version erlang tags with compatible elixir builds" do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       # An erlang tag on a base image that is no longer current contributes nothing.
       Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20240101", ["arm64"])
@@ -46,11 +208,42 @@ defmodule Bob.Job.DockerCheckerTest do
       assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
                [{"1.18.0", "27.0", "ubuntu", "noble-20250101", "amd64"}]
     end
+
+    test "expands only over the latest patch per erlang minor" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-27.0.1", "sha2"}])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0.1-ubuntu-noble-20250101", ["amd64"])
+      # An erlang tag that is not the latest patch, e.g. built on user request,
+      # contributes nothing.
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
+
+      assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
+               [{"1.18.0", "27.0.1", "ubuntu", "noble-20250101", "amd64"}]
+    end
+
+    test "expands only over the latest elixir build per minor and otp major" do
+      Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+
+      Bob.FakeHttpClient.stub(
+        :get,
+        @builds_txt_url,
+        200,
+        "v1.18.0-otp-27 abc123\nv1.18.4-otp-27 def456\n"
+      )
+
+      assert Enum.to_list(DockerChecker.expected_elixir_tags()) ==
+               [{"1.18.4", "27.0", "ubuntu", "noble-20250101", "amd64"}]
+    end
   end
 
   describe "elixir/0" do
     setup do
       Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+      Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha"}])
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
       :ok

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -10,6 +10,7 @@ defmodule Bob.Job.DockerCheckerTest do
 
   setup do
     Bob.FakeGitHub.reset()
+    Bob.Cache.clear()
     :ok
   end
 

--- a/test/bob/oauth_test.exs
+++ b/test/bob/oauth_test.exs
@@ -1,0 +1,49 @@
+defmodule Bob.OAuthTest do
+  use ExUnit.Case, async: true
+
+  alias Bob.OAuth
+
+  describe "generate_code_verifier/0" do
+    test "returns a 43-character url-safe string" do
+      verifier = OAuth.generate_code_verifier()
+
+      assert String.length(verifier) == 43
+      assert verifier =~ ~r/^[A-Za-z0-9_-]+$/
+    end
+
+    test "returns a unique value per call" do
+      assert OAuth.generate_code_verifier() != OAuth.generate_code_verifier()
+    end
+  end
+
+  describe "generate_code_challenge/1" do
+    test "returns the url-encoded sha256 of the verifier" do
+      assert OAuth.generate_code_challenge("verifier") ==
+               Base.url_encode64(:crypto.hash(:sha256, "verifier"), padding: false)
+    end
+  end
+
+  describe "authorization_url/1" do
+    test "builds the hexpm authorize url with pkce parameters" do
+      url =
+        OAuth.authorization_url(
+          state: "state123",
+          code_challenge: "challenge123",
+          redirect_uri: "http://localhost:4003/oauth/callback"
+        )
+
+      assert %URI{} = uri = URI.parse(url)
+      assert url =~ "http://localhost:4000/oauth/authorize?"
+
+      assert URI.decode_query(uri.query) == %{
+               "response_type" => "code",
+               "client_id" => "b0b00000-0000-4000-8000-000000000b0b",
+               "redirect_uri" => "http://localhost:4003/oauth/callback",
+               "scope" => "api:read",
+               "state" => "state123",
+               "code_challenge" => "challenge123",
+               "code_challenge_method" => "S256"
+             }
+    end
+  end
+end

--- a/test/bob/queue/maintenance_test.exs
+++ b/test/bob/queue/maintenance_test.exs
@@ -2,6 +2,8 @@ defmodule Bob.Queue.MaintenanceTest do
   use Bob.DataCase
 
   alias Bob.Queue.{Maintenance, Job, Failure, Term}
+  alias Bob.BuildRequests
+  alias Bob.BuildRequests.BuildRequest
 
   @hour 60 * 60
   @day 24 * @hour
@@ -112,5 +114,38 @@ defmodule Bob.Queue.MaintenanceTest do
     Maintenance.run()
 
     assert [%Job{state: "queued"}] = Repo.all(Job)
+  end
+
+  defp insert_build_request(state, inserted_at) do
+    {:ok, request} =
+      BuildRequests.create(%{
+        username: "eric",
+        kind: "erlang",
+        erlang: "27.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 2
+      })
+
+    request
+    |> Ecto.Changeset.change(state: state, inserted_at: inserted_at)
+    |> Repo.update!()
+  end
+
+  test "prunes finished build requests past the retention window" do
+    insert_build_request("completed", ago(91 * @day))
+
+    Maintenance.run()
+
+    assert Repo.all(BuildRequest) == []
+  end
+
+  test "keeps recent and pending build requests" do
+    insert_build_request("completed", DateTime.utc_now())
+    insert_build_request("pending", ago(91 * @day))
+
+    Maintenance.run()
+
+    assert Enum.map(Repo.all(BuildRequest), & &1.state) |> Enum.sort() == ["completed", "pending"]
   end
 end

--- a/test/bob/store_test.exs
+++ b/test/bob/store_test.exs
@@ -8,42 +8,6 @@ defmodule Bob.StoreTest do
     :ok
   end
 
-  describe "fetch_built_refs/1" do
-    test "parses lines into a ref_name => ref map" do
-      body = """
-      OTP-26.2 abc123 2026-01-01T00:00:00Z hash1
-      OTP-27.0 def456 2026-02-01T00:00:00Z hash2
-      """
-
-      Bob.FakeHttpClient.stub(
-        :get,
-        "https://s3.amazonaws.com/s3.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt",
-        200,
-        body
-      )
-
-      assert Store.fetch_built_refs("builds/otp/amd64/ubuntu-24.04") == %{
-               "OTP-26.2" => "abc123",
-               "OTP-27.0" => "def456"
-             }
-    end
-
-    test "returns an empty map when builds.txt does not exist yet" do
-      assert Store.fetch_built_refs("builds/otp/amd64/ubuntu-26.04") == %{}
-    end
-
-    test "returns an empty map when builds.txt is empty" do
-      Bob.FakeHttpClient.stub(
-        :get,
-        "https://s3.amazonaws.com/s3.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt",
-        200,
-        ""
-      )
-
-      assert Store.fetch_built_refs("builds/otp/amd64/ubuntu-24.04") == %{}
-    end
-  end
-
   describe "fetch_text/1" do
     test "returns the body for an existing object" do
       Bob.FakeHttpClient.reset()

--- a/test/bob_web/components/layouts_test.exs
+++ b/test/bob_web/components/layouts_test.exs
@@ -1,0 +1,27 @@
+defmodule BobWeb.LayoutsTest do
+  use ExUnit.Case, async: true
+
+  alias BobWeb.Layouts
+
+  describe "nav_class/2" do
+    test "marks the tab active when the path matches its target" do
+      for path <- ["/", "/artifacts", "/docker", "/request"] do
+        assert "bob-nav__tab--active" in Layouts.nav_class(path, path)
+      end
+    end
+
+    test "does not mark other tabs active" do
+      refute "bob-nav__tab--active" in Layouts.nav_class("/request", "/docker")
+    end
+  end
+
+  describe "menu_class/2" do
+    test "marks the menu item active when the path matches its target" do
+      assert "bob-menu__item--active" in Layouts.menu_class("/request", "/request")
+    end
+
+    test "does not mark other menu items active" do
+      refute "bob-menu__item--active" in Layouts.menu_class("/request", "/")
+    end
+  end
+end

--- a/test/bob_web/controllers/oauth_controller_test.exs
+++ b/test/bob_web/controllers/oauth_controller_test.exs
@@ -1,0 +1,155 @@
+defmodule BobWeb.OAuthControllerTest do
+  use BobWeb.ConnCase
+
+  setup do
+    Bob.FakeHexpm.reset()
+    :ok
+  end
+
+  @tokens %{
+    "access_token" => "eyJ.access",
+    "refresh_token" => "eyJ.refresh",
+    "expires_in" => 1800
+  }
+
+  describe "GET /oauth/login" do
+    test "redirects to the hexpm authorize url and stores the flow in the session", %{conn: conn} do
+      conn = get(conn, ~p"/oauth/login")
+
+      location = redirected_to(conn, 302)
+      assert location =~ "http://localhost:4000/oauth/authorize?"
+
+      query = URI.decode_query(URI.parse(location).query)
+      assert query["response_type"] == "code"
+      assert query["scope"] == "api:read"
+      assert query["code_challenge_method"] == "S256"
+      assert query["redirect_uri"] == "http://localhost:4002/oauth/callback"
+
+      assert get_session(conn, "oauth_state") == query["state"]
+      assert get_session(conn, "oauth_code_verifier")
+      assert get_session(conn, "oauth_return_to") == "/"
+    end
+
+    test "stores the sanitized return path", %{conn: conn} do
+      conn = get(conn, ~p"/oauth/login?return_to=/request")
+      assert get_session(conn, "oauth_return_to") == "/request"
+
+      conn = get(conn, ~p"/oauth/login?return_to=//evil.com")
+      assert get_session(conn, "oauth_return_to") == "/"
+    end
+
+    test "redirects straight to the return path when already logged in", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(session_fixture())
+        |> get(~p"/oauth/login?return_to=/request")
+
+      assert redirected_to(conn, 302) == "/request"
+    end
+  end
+
+  describe "GET /oauth/callback" do
+    test "logs the user in and redirects to the stored return path", %{conn: conn} do
+      Bob.FakeHexpm.stub(:exchange_code, {:ok, @tokens})
+      Bob.FakeHexpm.stub(:get_current_user, {:ok, %{"username" => "eric"}})
+
+      conn =
+        conn
+        |> init_test_session(%{
+          "oauth_state" => "state123",
+          "oauth_code_verifier" => "verifier",
+          "oauth_return_to" => "/request"
+        })
+        |> get(~p"/oauth/callback?code=code123&state=state123")
+
+      assert redirected_to(conn, 302) == "/request"
+      assert get_session(conn, "current_user") == %{"username" => "eric"}
+      assert get_session(conn, "access_token") == "eyJ.access"
+      assert get_session(conn, "refresh_token") == "eyJ.refresh"
+      assert get_session(conn, "token_expires_at")
+      refute get_session(conn, "oauth_state")
+      refute get_session(conn, "oauth_code_verifier")
+      refute get_session(conn, "oauth_return_to")
+    end
+
+    test "rejects a state mismatch", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{"oauth_state" => "expected", "oauth_code_verifier" => "verifier"})
+        |> get(~p"/oauth/callback?code=code123&state=wrong")
+
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid OAuth state"
+      refute get_session(conn, "current_user")
+    end
+
+    test "rejects a missing state", %{conn: conn} do
+      conn = get(conn, ~p"/oauth/callback?code=code123")
+
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid OAuth state"
+    end
+
+    test "surfaces errors returned by hexpm", %{conn: conn} do
+      conn = get(conn, ~p"/oauth/callback?error=access_denied")
+
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "access_denied"
+    end
+
+    test "rejects a missing code", %{conn: conn} do
+      conn =
+        conn
+        |> init_test_session(%{"oauth_state" => "state123", "oauth_code_verifier" => "verifier"})
+        |> get(~p"/oauth/callback?state=state123")
+
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "missing OAuth code"
+    end
+
+    test "shows an error when the code exchange fails", %{conn: conn} do
+      Bob.FakeHexpm.stub(:exchange_code, {:error, {400, "invalid_grant"}})
+
+      conn =
+        init_test_session(conn, %{
+          "oauth_state" => "state123",
+          "oauth_code_verifier" => "verifier"
+        })
+
+      {conn, log} =
+        ExUnit.CaptureLog.with_log(fn ->
+          get(conn, ~p"/oauth/callback?code=code123&state=state123")
+        end)
+
+      assert log =~ "code exchange failed"
+      assert redirected_to(conn, 302) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "logging in to hex.pm failed"
+      refute get_session(conn, "current_user")
+      refute get_session(conn, "access_token")
+    end
+  end
+
+  describe "POST /oauth/logout" do
+    test "drops the session and redirects home", %{conn: conn} do
+      Bob.FakeHexpm.stub(:revoke_token, :ok)
+
+      conn =
+        conn
+        |> init_test_session(session_fixture())
+        |> post(~p"/oauth/logout")
+
+      assert redirected_to(conn, 302) == "/"
+      assert conn.private.plug_session_info == :drop
+      assert conn.assigns.current_user == nil
+    end
+  end
+
+  defp session_fixture() do
+    %{
+      "current_user" => %{"username" => "eric"},
+      "access_token" => "eyJ.access",
+      "refresh_token" => "eyJ.refresh",
+      "token_expires_at" => System.system_time(:second) + 1800
+    }
+  end
+end

--- a/test/bob_web/controllers/oauth_controller_test.exs
+++ b/test/bob_web/controllers/oauth_controller_test.exs
@@ -64,9 +64,10 @@ defmodule BobWeb.OAuthControllerTest do
 
       assert redirected_to(conn, 302) == "/request"
       assert get_session(conn, "current_user") == %{"username" => "eric"}
-      assert get_session(conn, "access_token") == "eyJ.access"
       assert get_session(conn, "refresh_token") == "eyJ.refresh"
       assert get_session(conn, "token_expires_at")
+      # The access token is used once to fetch the username, never stored.
+      refute get_session(conn, "access_token")
       refute get_session(conn, "oauth_state")
       refute get_session(conn, "oauth_code_verifier")
       refute get_session(conn, "oauth_return_to")
@@ -147,7 +148,6 @@ defmodule BobWeb.OAuthControllerTest do
   defp session_fixture() do
     %{
       "current_user" => %{"username" => "eric"},
-      "access_token" => "eyJ.access",
       "refresh_token" => "eyJ.refresh",
       "token_expires_at" => System.system_time(:second) + 1800
     }

--- a/test/bob_web/endpoint_config_test.exs
+++ b/test/bob_web/endpoint_config_test.exs
@@ -11,6 +11,8 @@ defmodule BobWeb.EndpointConfigTest do
     "BOB_HOSTNAME" => "gce",
     "BOB_LOCAL_JOBS" => "[]",
     "BOB_MASTER_URL" => "https://bob.hex.pm",
+    "BOB_OAUTH_CLIENT_ID" => "client-id",
+    "BOB_OAUTH_CLIENT_SECRET" => "client-secret",
     "BOB_PARALLEL_JOBS" => "10",
     "BOB_PORT" => "4003",
     "BOB_REMOTE_JOBS" => "[]",

--- a/test/bob_web/live/request_live_test.exs
+++ b/test/bob_web/live/request_live_test.exs
@@ -7,16 +7,19 @@ defmodule BobWeb.RequestLiveTest do
   alias Bob.BuildRequests.BuildRequest
   alias Bob.Queue.Job
 
-  @builds_txt_url "https://s3.amazonaws.com/s3.hex.pm/builds/elixir/builds.txt"
-
   setup %{conn: conn} do
-    Bob.FakeHttpClient.reset()
     Bob.FakeGitHub.reset()
     Bob.Cache.clear()
 
     Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
     Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-27.0.1", "sha2"}])
-    Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
+
+    Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+      %{
+        "tag_name" => "v1.18.0",
+        "assets" => [%{"name" => "elixir-otp-27.zip"}]
+      }
+    ])
 
     {:ok, conn: conn}
   end
@@ -26,6 +29,12 @@ defmodule BobWeb.RequestLiveTest do
       "current_user" => %{"username" => "eric"},
       "token_expires_at" => System.system_time(:second) + 1800
     })
+  end
+
+  defp select_names(html) do
+    ~r/<select name="([^"]+)"/
+    |> Regex.scan(html, capture: :all_but_first)
+    |> List.flatten()
   end
 
   defp select_erlang(view, erlang) do
@@ -48,7 +57,9 @@ defmodule BobWeb.RequestLiveTest do
 
     assert html =~ "Request a build"
     assert html =~ "Loading versions"
-    refute render_async(view) =~ "Loading versions"
+    html = render_async(view)
+    refute html =~ "Loading versions"
+    refute html =~ "choose"
 
     html = view |> element("form") |> render_change(%{"kind" => "erlang", "os" => "ubuntu"})
     assert html =~ "noble-20250101"
@@ -64,6 +75,48 @@ defmodule BobWeb.RequestLiveTest do
 
     assert html =~ "27.0"
     refute html =~ ">24.1<"
+  end
+
+  test "offers erlang before bare elixir releases and infers OTP from erlang", %{conn: conn} do
+    Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-28.0", "sha2"}])
+
+    Bob.FakeGitHub.stub_releases("elixir-lang/elixir", [
+      %{"tag_name" => "v1.19.0", "assets" => [%{"name" => "elixir-otp-28.zip"}]},
+      %{"tag_name" => "v1.18.0", "assets" => [%{"name" => "elixir-otp-27.zip"}]}
+    ])
+
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+
+    html =
+      view
+      |> element("form")
+      |> render_change(%{
+        "kind" => "elixir",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101"
+      })
+
+    assert select_names(html) == ["kind", "os", "os_version", "erlang", "elixir"]
+    assert html =~ "27.0"
+    assert html =~ "28.0"
+    refute html =~ ~s(value="1.19.0")
+    refute html =~ ~s(value="1.18.0")
+    refute html =~ "otp-"
+
+    html =
+      view
+      |> element("form")
+      |> render_change(%{
+        "kind" => "elixir",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "27.0"
+      })
+
+    assert html =~ ~s(value="1.18.0")
+    refute html =~ ~s(value="1.19.0")
+    refute html =~ "otp-"
   end
 
   test "submits an erlang build request", %{conn: conn} do
@@ -98,7 +151,7 @@ defmodule BobWeb.RequestLiveTest do
       "kind" => "elixir",
       "os" => "ubuntu",
       "os_version" => "noble-20250101",
-      "elixir_build" => "1.18.0-otp-27",
+      "elixir" => "1.18.0",
       "erlang" => "27.0"
     }
 
@@ -139,6 +192,40 @@ defmodule BobWeb.RequestLiveTest do
     assert html =~ "already built"
     assert Repo.all(BuildRequest) == []
     assert Repo.all(Job) == []
+  end
+
+  test "replaces old flash messages", %{conn: conn} do
+    Bob.Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+    Bob.Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+    select_erlang(view, "27.0")
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "27.0"
+      })
+
+    assert html =~ "already built"
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "24.1"
+      })
+
+    assert html =~ "Select a value for every field"
+    refute html =~ "already built"
   end
 
   test "rejects submissions over the hourly build limit", %{conn: conn} do

--- a/test/bob_web/live/request_live_test.exs
+++ b/test/bob_web/live/request_live_test.exs
@@ -176,6 +176,7 @@ defmodule BobWeb.RequestLiveTest do
   test "reports already built tags", %{conn: conn} do
     Bob.Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
     Bob.Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+    Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
 
     {:ok, view, _html} = live(log_in(conn), ~p"/request")
     render_async(view)
@@ -199,6 +200,7 @@ defmodule BobWeb.RequestLiveTest do
   test "replaces old flash messages", %{conn: conn} do
     Bob.Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
     Bob.Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+    Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
 
     {:ok, view, _html} = live(log_in(conn), ~p"/request")
     render_async(view)

--- a/test/bob_web/live/request_live_test.exs
+++ b/test/bob_web/live/request_live_test.exs
@@ -1,0 +1,209 @@
+defmodule BobWeb.RequestLiveTest do
+  use BobWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Bob.Artifacts.BaseImageTag
+  alias Bob.BuildRequests.BuildRequest
+  alias Bob.Queue.Job
+
+  @builds_txt_url "https://s3.amazonaws.com/s3.hex.pm/builds/elixir/builds.txt"
+
+  setup %{conn: conn} do
+    Bob.FakeHttpClient.reset()
+    Bob.FakeGitHub.reset()
+    Bob.Cache.clear()
+
+    Repo.insert!(%BaseImageTag{repo: "library/ubuntu", tag: "noble-20250101"})
+    Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-27.0.1", "sha2"}])
+    Bob.FakeHttpClient.stub(:get, @builds_txt_url, 200, "v1.18.0-otp-27 abc123\n")
+
+    {:ok, conn: conn}
+  end
+
+  defp log_in(conn) do
+    init_test_session(conn, %{
+      "current_user" => %{"username" => "eric"},
+      "token_expires_at" => System.system_time(:second) + 1800
+    })
+  end
+
+  defp select_erlang(view, erlang) do
+    view
+    |> element("form")
+    |> render_change(%{
+      "kind" => "erlang",
+      "os" => "ubuntu",
+      "os_version" => "noble-20250101",
+      "erlang" => erlang
+    })
+  end
+
+  test "redirects anonymous users to the login page", %{conn: conn} do
+    assert {:error, {:redirect, %{to: "/oauth/login"}}} = live(conn, ~p"/request")
+  end
+
+  test "renders the form for a logged in user", %{conn: conn} do
+    {:ok, view, html} = live(log_in(conn), ~p"/request")
+
+    assert html =~ "Request a build"
+    assert html =~ "Loading versions"
+    refute render_async(view) =~ "Loading versions"
+
+    html = view |> element("form") |> render_change(%{"kind" => "erlang", "os" => "ubuntu"})
+    assert html =~ "noble-20250101"
+  end
+
+  test "offers only erlang versions the build rules allow", %{conn: conn} do
+    Bob.FakeGitHub.stub_refs("erlang/otp", [{"OTP-27.0", "sha1"}, {"OTP-24.1", "sha2"}])
+
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+
+    html = select_erlang(view, "")
+
+    assert html =~ "27.0"
+    refute html =~ ">24.1<"
+  end
+
+  test "submits an erlang build request", %{conn: conn} do
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+    select_erlang(view, "27.0")
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "27.0"
+      })
+
+    assert html =~ "Build queued"
+    assert html =~ "27.0-ubuntu-noble-20250101"
+
+    assert [%BuildRequest{username: "eric", kind: "erlang", erlang: "27.0"}] =
+             Repo.all(BuildRequest)
+
+    assert Enum.count(Repo.all(Job)) == 2
+  end
+
+  test "submits an elixir build request and explains the staged erlang base", %{conn: conn} do
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+
+    params = %{
+      "kind" => "elixir",
+      "os" => "ubuntu",
+      "os_version" => "noble-20250101",
+      "elixir_build" => "1.18.0-otp-27",
+      "erlang" => "27.0"
+    }
+
+    html = view |> element("form") |> render_change(params)
+    assert html =~ "does not exist yet"
+
+    html = view |> element("form") |> render_submit(params)
+    assert html =~ "Build queued"
+
+    assert [%BuildRequest{kind: "elixir", elixir: "1.18.0", erlang: "27.0", builds_count: 4}] =
+             Repo.all(BuildRequest)
+
+    assert Repo.all(Job) |> Enum.map(& &1.module_key) |> Enum.sort() ==
+             Enum.sort([
+               {Bob.Job.BuildDockerErlang, "amd64"},
+               {Bob.Job.BuildDockerErlang, "arm64"}
+             ])
+  end
+
+  test "reports already built tags", %{conn: conn} do
+    Bob.Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
+    Bob.Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])
+
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+    select_erlang(view, "27.0")
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "27.0"
+      })
+
+    assert html =~ "already built"
+    assert Repo.all(BuildRequest) == []
+    assert Repo.all(Job) == []
+  end
+
+  test "rejects submissions over the hourly build limit", %{conn: conn} do
+    {:ok, _request} =
+      Bob.BuildRequests.create(%{
+        username: "eric",
+        kind: "erlang",
+        erlang: "26.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 10
+      })
+
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+    select_erlang(view, "27.0")
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "27.0"
+      })
+
+    assert html =~ "limit of 10 requested builds"
+    assert Repo.all(Job) == []
+  end
+
+  test "rejects values outside the option lists", %{conn: conn} do
+    {:ok, view, _html} = live(log_in(conn), ~p"/request")
+    render_async(view)
+
+    html =
+      view
+      |> element("form")
+      |> render_submit(%{
+        "kind" => "erlang",
+        "os" => "ubuntu",
+        "os_version" => "noble-20250101",
+        "erlang" => "24.1"
+      })
+
+    assert html =~ "Select a value for every field"
+    assert Repo.all(Job) == []
+    assert Repo.all(BuildRequest) == []
+  end
+
+  test "lists the user's recent requests", %{conn: conn} do
+    {:ok, _request} =
+      Bob.BuildRequests.create(%{
+        username: "eric",
+        kind: "erlang",
+        erlang: "26.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 2
+      })
+
+    {:ok, _view, html} = live(log_in(conn), ~p"/request")
+
+    assert html =~ "Your recent requests"
+    assert html =~ "26.0-ubuntu-noble-20250101"
+    assert html =~ "pending"
+  end
+end

--- a/test/bob_web/live/request_live_test.exs
+++ b/test/bob_web/live/request_live_test.exs
@@ -60,6 +60,8 @@ defmodule BobWeb.RequestLiveTest do
     html = render_async(view)
     refute html =~ "Loading versions"
     refute html =~ "choose"
+    assert html =~ "Pending requests"
+    assert html =~ "No pending requests."
 
     html = view |> element("form") |> render_change(%{"kind" => "erlang", "os" => "ubuntu"})
     assert html =~ "noble-20250101"
@@ -292,5 +294,50 @@ defmodule BobWeb.RequestLiveTest do
     assert html =~ "Your recent requests"
     assert html =~ "26.0-ubuntu-noble-20250101"
     assert html =~ "pending"
+  end
+
+  test "lists global pending requests", %{conn: conn} do
+    {:ok, _my_request} =
+      Bob.BuildRequests.create(%{
+        username: "eric",
+        kind: "erlang",
+        erlang: "26.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 2
+      })
+
+    {:ok, _other_request} =
+      Bob.BuildRequests.create(%{
+        username: "jose",
+        kind: "elixir",
+        elixir: "1.18.0",
+        erlang: "27.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 4
+      })
+
+    {:ok, completed_request} =
+      Bob.BuildRequests.create(%{
+        username: "dashbit",
+        kind: "erlang",
+        erlang: "28.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 2
+      })
+
+    completed_request
+    |> Ecto.Changeset.change(state: "completed")
+    |> Repo.update!()
+
+    {:ok, _view, html} = live(log_in(conn), ~p"/request")
+
+    assert html =~ "Pending requests"
+    assert html =~ "jose"
+    assert html =~ "1.18.0-erlang-27.0-ubuntu-noble-20250101"
+    refute html =~ "dashbit"
+    refute html =~ "28.0-ubuntu-noble-20250101"
   end
 end

--- a/test/bob_web/live/request_live_test.exs
+++ b/test/bob_web/live/request_live_test.exs
@@ -278,8 +278,8 @@ defmodule BobWeb.RequestLiveTest do
     assert Repo.all(BuildRequest) == []
   end
 
-  test "lists the user's recent requests", %{conn: conn} do
-    {:ok, _request} =
+  test "lists recent requests across all users", %{conn: conn} do
+    {:ok, _mine} =
       Bob.BuildRequests.create(%{
         username: "eric",
         kind: "erlang",
@@ -289,11 +289,27 @@ defmodule BobWeb.RequestLiveTest do
         builds_count: 2
       })
 
+    {:ok, others} =
+      Bob.BuildRequests.create(%{
+        username: "jose",
+        kind: "erlang",
+        erlang: "28.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 2
+      })
+
+    others
+    |> Ecto.Changeset.change(state: "completed")
+    |> Repo.update!()
+
     {:ok, _view, html} = live(log_in(conn), ~p"/request")
 
-    assert html =~ "Your recent requests"
+    assert html =~ "Recent requests"
+    # Another user's request, in a finished state, still shows up.
+    assert html =~ "jose"
+    assert html =~ "28.0-ubuntu-noble-20250101"
     assert html =~ "26.0-ubuntu-noble-20250101"
-    assert html =~ "pending"
   end
 
   test "lists global pending requests", %{conn: conn} do
@@ -318,26 +334,10 @@ defmodule BobWeb.RequestLiveTest do
         builds_count: 4
       })
 
-    {:ok, completed_request} =
-      Bob.BuildRequests.create(%{
-        username: "dashbit",
-        kind: "erlang",
-        erlang: "28.0",
-        os: "ubuntu",
-        os_version: "noble-20250101",
-        builds_count: 2
-      })
-
-    completed_request
-    |> Ecto.Changeset.change(state: "completed")
-    |> Repo.update!()
-
     {:ok, _view, html} = live(log_in(conn), ~p"/request")
 
     assert html =~ "Pending requests"
     assert html =~ "jose"
     assert html =~ "1.18.0-erlang-27.0-ubuntu-noble-20250101"
-    refute html =~ "dashbit"
-    refute html =~ "28.0-ubuntu-noble-20250101"
   end
 end

--- a/test/bob_web/user_auth_test.exs
+++ b/test/bob_web/user_auth_test.exs
@@ -49,15 +49,14 @@ defmodule BobWeb.UserAuthTest do
       conn =
         conn
         |> put_session("current_user", @user)
-        |> put_session("access_token", "eyJ.old-access")
         |> put_session("refresh_token", "eyJ.old-refresh")
         |> put_session("token_expires_at", System.system_time(:second) + 60)
         |> UserAuth.fetch_current_user([])
 
       assert conn.assigns.current_user == @user
-      assert get_session(conn, "access_token") == "eyJ.new-access"
       assert get_session(conn, "refresh_token") == "eyJ.new-refresh"
       assert get_session(conn, "token_expires_at") > System.system_time(:second) + 1700
+      refute get_session(conn, "access_token")
     end
 
     test "logs the user out when the refresh fails", %{conn: conn} do
@@ -66,7 +65,6 @@ defmodule BobWeb.UserAuthTest do
       conn =
         conn
         |> put_session("current_user", @user)
-        |> put_session("access_token", "eyJ.old-access")
         |> put_session("refresh_token", "eyJ.old-refresh")
         |> put_session("token_expires_at", System.system_time(:second) - 1)
 
@@ -75,7 +73,6 @@ defmodule BobWeb.UserAuthTest do
       assert log =~ "token refresh failed"
       assert conn.assigns.current_user == nil
       refute get_session(conn, "current_user")
-      refute get_session(conn, "access_token")
       refute get_session(conn, "refresh_token")
     end
 
@@ -162,6 +159,7 @@ defmodule BobWeb.UserAuthTest do
 
     test "rejects protocol-relative and external urls" do
       assert UserAuth.safe_return_path("//evil.com") == "/"
+      assert UserAuth.safe_return_path("/\\evil.com") == "/"
       assert UserAuth.safe_return_path("https://evil.com") == "/"
       assert UserAuth.safe_return_path(nil) == "/"
     end

--- a/test/bob_web/user_auth_test.exs
+++ b/test/bob_web/user_auth_test.exs
@@ -1,0 +1,169 @@
+defmodule BobWeb.UserAuthTest do
+  use BobWeb.ConnCase
+
+  import ExUnit.CaptureLog
+
+  alias BobWeb.UserAuth
+
+  @user %{"username" => "eric"}
+
+  setup %{conn: conn} do
+    Bob.FakeHexpm.reset()
+
+    conn =
+      conn
+      |> Map.replace!(:secret_key_base, BobWeb.Endpoint.config(:secret_key_base))
+      |> init_test_session(%{})
+
+    {:ok, conn: conn}
+  end
+
+  describe "fetch_current_user/2" do
+    test "assigns nil without a session user", %{conn: conn} do
+      conn = UserAuth.fetch_current_user(conn, [])
+
+      assert conn.assigns.current_user == nil
+    end
+
+    test "assigns the session user when the token is fresh", %{conn: conn} do
+      conn =
+        conn
+        |> put_session("current_user", @user)
+        |> put_session("token_expires_at", System.system_time(:second) + 1800)
+        |> UserAuth.fetch_current_user([])
+
+      assert conn.assigns.current_user == @user
+    end
+
+    test "refreshes tokens close to expiry", %{conn: conn} do
+      Bob.FakeHexpm.stub(
+        :refresh_token,
+        {:ok,
+         %{
+           "access_token" => "eyJ.new-access",
+           "refresh_token" => "eyJ.new-refresh",
+           "expires_in" => 1800
+         }}
+      )
+
+      conn =
+        conn
+        |> put_session("current_user", @user)
+        |> put_session("access_token", "eyJ.old-access")
+        |> put_session("refresh_token", "eyJ.old-refresh")
+        |> put_session("token_expires_at", System.system_time(:second) + 60)
+        |> UserAuth.fetch_current_user([])
+
+      assert conn.assigns.current_user == @user
+      assert get_session(conn, "access_token") == "eyJ.new-access"
+      assert get_session(conn, "refresh_token") == "eyJ.new-refresh"
+      assert get_session(conn, "token_expires_at") > System.system_time(:second) + 1700
+    end
+
+    test "logs the user out when the refresh fails", %{conn: conn} do
+      Bob.FakeHexpm.stub(:refresh_token, {:error, {401, "invalid_grant"}})
+
+      conn =
+        conn
+        |> put_session("current_user", @user)
+        |> put_session("access_token", "eyJ.old-access")
+        |> put_session("refresh_token", "eyJ.old-refresh")
+        |> put_session("token_expires_at", System.system_time(:second) - 1)
+
+      {conn, log} = with_log(fn -> UserAuth.fetch_current_user(conn, []) end)
+
+      assert log =~ "token refresh failed"
+      assert conn.assigns.current_user == nil
+      refute get_session(conn, "current_user")
+      refute get_session(conn, "access_token")
+      refute get_session(conn, "refresh_token")
+    end
+
+    test "logs the user out when the token expired without a refresh token", %{conn: conn} do
+      conn =
+        conn
+        |> put_session("current_user", @user)
+        |> put_session("token_expires_at", System.system_time(:second) - 1)
+
+      {conn, _log} = with_log(fn -> UserAuth.fetch_current_user(conn, []) end)
+
+      assert conn.assigns.current_user == nil
+      refute get_session(conn, "current_user")
+    end
+  end
+
+  describe "require_authenticated_user/2" do
+    test "passes an authenticated conn through", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:current_user, @user)
+        |> UserAuth.require_authenticated_user([])
+
+      refute conn.halted
+    end
+
+    test "redirects anonymous users to the login page", %{conn: conn} do
+      conn =
+        %{conn | path_info: ["request"], request_path: "/request"}
+        |> Phoenix.Controller.fetch_flash()
+        |> UserAuth.require_authenticated_user([])
+
+      assert conn.halted
+      assert redirected_to(conn, 302) == "/oauth/login"
+      assert get_session(conn, "oauth_return_to") == "/request"
+    end
+  end
+
+  describe "on_mount/4" do
+    test "mount_current_user assigns from the session" do
+      assert {:cont, socket} =
+               UserAuth.on_mount(
+                 :mount_current_user,
+                 %{},
+                 %{"current_user" => @user},
+                 %Phoenix.LiveView.Socket{}
+               )
+
+      assert socket.assigns.current_user == @user
+
+      assert {:cont, socket} =
+               UserAuth.on_mount(:mount_current_user, %{}, %{}, %Phoenix.LiveView.Socket{})
+
+      assert socket.assigns.current_user == nil
+    end
+
+    test "ensure_authenticated halts anonymous sockets" do
+      socket = %Phoenix.LiveView.Socket{
+        endpoint: BobWeb.Endpoint,
+        router: BobWeb.Router
+      }
+
+      assert {:halt, socket} = UserAuth.on_mount(:ensure_authenticated, %{}, %{}, socket)
+      assert {:redirect, %{to: "/oauth/login"}} = socket.redirected
+    end
+
+    test "ensure_authenticated continues authenticated sockets" do
+      assert {:cont, socket} =
+               UserAuth.on_mount(
+                 :ensure_authenticated,
+                 %{},
+                 %{"current_user" => @user},
+                 %Phoenix.LiveView.Socket{}
+               )
+
+      assert socket.assigns.current_user == @user
+    end
+  end
+
+  describe "safe_return_path/1" do
+    test "allows normal paths" do
+      assert UserAuth.safe_return_path("/request") == "/request"
+    end
+
+    test "rejects protocol-relative and external urls" do
+      assert UserAuth.safe_return_path("//evil.com") == "/"
+      assert UserAuth.safe_return_path("https://evil.com") == "/"
+      assert UserAuth.safe_return_path(nil) == "/"
+    end
+  end
+end

--- a/test/support/fake_github.ex
+++ b/test/support/fake_github.ex
@@ -1,0 +1,15 @@
+defmodule Bob.FakeGitHub do
+  def fetch_repo_refs(repo) do
+    :persistent_term.get({__MODULE__, repo}, [])
+  end
+
+  def stub_refs(repo, refs) do
+    :persistent_term.put({__MODULE__, repo}, refs)
+  end
+
+  def reset() do
+    for {{__MODULE__, _repo} = key, _value} <- :persistent_term.get() do
+      :persistent_term.erase(key)
+    end
+  end
+end

--- a/test/support/fake_github.ex
+++ b/test/support/fake_github.ex
@@ -11,6 +11,10 @@ defmodule Bob.FakeGitHub do
     :persistent_term.get({__MODULE__, {:releases, repo}}, [])
   end
 
+  def fetch_recent_releases(repo) do
+    fetch_repo_releases(repo)
+  end
+
   def stub_refs(repo, refs) do
     :persistent_term.put({__MODULE__, repo}, refs)
   end

--- a/test/support/fake_github.ex
+++ b/test/support/fake_github.ex
@@ -3,12 +3,24 @@ defmodule Bob.FakeGitHub do
     :persistent_term.get({__MODULE__, repo}, [])
   end
 
+  def fetch_repo_tags(repo) do
+    fetch_repo_refs(repo)
+  end
+
+  def fetch_repo_releases(repo) do
+    :persistent_term.get({__MODULE__, {:releases, repo}}, [])
+  end
+
   def stub_refs(repo, refs) do
     :persistent_term.put({__MODULE__, repo}, refs)
   end
 
+  def stub_releases(repo, releases) do
+    :persistent_term.put({__MODULE__, {:releases, repo}}, releases)
+  end
+
   def reset() do
-    for {{__MODULE__, _repo} = key, _value} <- :persistent_term.get() do
+    for {{__MODULE__, _key} = key, _value} <- :persistent_term.get() do
       :persistent_term.erase(key)
     end
   end

--- a/test/support/fake_hexpm.ex
+++ b/test/support/fake_hexpm.ex
@@ -1,0 +1,29 @@
+defmodule Bob.FakeHexpm do
+  @behaviour Bob.Hexpm
+
+  @impl true
+  def exchange_code(_code, _code_verifier, _redirect_uri), do: stubbed(:exchange_code)
+
+  @impl true
+  def refresh_token(_refresh_token), do: stubbed(:refresh_token)
+
+  @impl true
+  def revoke_token(_token), do: stubbed(:revoke_token)
+
+  @impl true
+  def get_current_user(_access_token), do: stubbed(:get_current_user)
+
+  def stub(function, response) do
+    :persistent_term.put({__MODULE__, function}, response)
+  end
+
+  def reset() do
+    for {{__MODULE__, _function} = key, _value} <- :persistent_term.get() do
+      :persistent_term.erase(key)
+    end
+  end
+
+  defp stubbed(function) do
+    :persistent_term.get({__MODULE__, function}, {:error, :not_stubbed})
+  end
+end


### PR DESCRIPTION
* Only automatically trigger builds for the latest patch per Erlang and Elixir version family.
    Docker images were built for every Erlang patch release crossed with every Elixir build, producing tens of thousands of redundant tags per new OS version. Collapse the expected set to the newest ref per Erlang major.minor line and the newest Elixir build per minor and OTP major, and restrict the Elixir expansion to that latest-patch Erlang set so historical or manually built Erlang tags no longer fan out.

* Add request build page
    Authenticated hex.pm users pick an image kind, OS, base image version, and the exact Erlang (and Elixir) version from dropdowns derived from the real OTP refs and Elixir builds, so submitted values are valid by construction. Versions load through a small read-through cache since listing OTP refs takes over a dozen GitHub requests. Recent requests are listed with their reconciliation state.