### PR TITLE
Speed up the jobs filter, cap job history at 10k, fix Docker tags filter alignment

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -428,6 +428,7 @@ pre,
 
 .filter-bar__meta {
   margin-left: auto;
+  align-self: center;
   color: var(--color-grey-400);
   font-size: 13px;
   white-space: nowrap;
@@ -587,6 +588,7 @@ pre,
 }
 
 .f-or {
+  align-self: center;
   color: var(--color-grey-400);
   padding: 0 1px;
   font-size: 12px;

--- a/lib/bob/queue/maintenance.ex
+++ b/lib/bob/queue/maintenance.ex
@@ -3,7 +3,7 @@ defmodule Bob.Queue.Maintenance do
   Periodic queue maintenance, guarded by a Postgres advisory lock so exactly
   one master instance does the work: requeues stale running jobs (failing them
   once their requeues are exhausted), prunes expired backoff rows, and prunes
-  old job history.
+  job history that is older than the retention window or beyond the row cap.
   """
 
   use GenServer
@@ -21,6 +21,7 @@ defmodule Bob.Queue.Maintenance do
   @max_timeout_requeues 2
   @backoff_expiry_seconds 7 * 24 * 60 * 60
   @history_retention_seconds 90 * 24 * 60 * 60
+  @history_max_jobs 10_000
   @advisory_lock_key 4_771_001
 
   def start_link([]) do
@@ -99,6 +100,22 @@ defmodule Bob.Queue.Maintenance do
     Repo.delete_all(
       from(j in Job, where: j.state in ["done", "failed"] and j.finished_at < ^cutoff)
     )
+
+    max = history_max_jobs()
+
+    excess =
+      from(j in Job,
+        where: j.state in ["done", "failed"],
+        order_by: [desc: j.finished_at, desc: j.id],
+        offset: ^max,
+        select: j.id
+      )
+
+    Repo.delete_all(from(j in Job, where: j.id in subquery(excess)))
+  end
+
+  defp history_max_jobs() do
+    Application.get_env(:bob, :history_max_jobs, @history_max_jobs)
   end
 
   defp schedule_tick() do

--- a/lib/bob_web/components/core_components.ex
+++ b/lib/bob_web/components/core_components.ex
@@ -93,6 +93,7 @@ defmodule BobWeb.CoreComponents do
   attr(:page, :integer, required: true)
   attr(:unit, :string, default: nil)
   attr(:total, :integer, default: nil)
+  attr(:more, :boolean, default: nil)
 
   def pager(assigns) do
     assigns =
@@ -133,6 +134,8 @@ defmodule BobWeb.CoreComponents do
   def format_unit(nil, _count), do: nil
   def format_unit(unit, 1), do: singular_unit(unit)
   def format_unit(unit, _count), do: unit
+
+  defp next_disabled?(%{more: more}) when is_boolean(more), do: not more
 
   defp next_disabled?(%{count: count, page: page}) when count < page, do: true
 

--- a/lib/bob_web/live/jobs_live.ex
+++ b/lib/bob_web/live/jobs_live.ex
@@ -28,11 +28,15 @@ defmodule BobWeb.JobsLive do
         queue_total: 0,
         queued: [],
         past: [],
-        past_total: 0
+        past_more: false
       )
 
-    socket = if connected?(socket), do: load(socket), else: socket
-    socket = if connected?(socket), do: schedule_tick(socket), else: socket
+    socket =
+      if connected?(socket) do
+        socket |> assign(modules: load_modules()) |> load() |> schedule_tick()
+      else
+        socket
+      end
 
     {:ok, socket}
   end
@@ -91,13 +95,10 @@ defmodule BobWeb.JobsLive do
   defp step("prev", page), do: -page
 
   defp load(socket) do
-    modules =
-      Bob.Queue.job_modules()
-      |> Enum.sort_by(&{housekeeping?(&1), module_name(&1)})
-
     selected = socket.assigns.selected
-    filter = Enum.filter(modules, &MapSet.member?(selected, module_name(&1)))
+    filter = Enum.filter(socket.assigns.modules, &MapSet.member?(selected, module_name(&1)))
     queued_counts = Map.new(Bob.Queue.queue_sizes())
+    running = Bob.Queue.running(filter)
 
     queue_total =
       queued_counts
@@ -105,17 +106,32 @@ defmodule BobWeb.JobsLive do
       |> Enum.map(fn {_mod, count} -> count end)
       |> Enum.sum()
 
+    past = Bob.Queue.recent(@past_page + 1, socket.assigns.past_offset, filter)
+
     assign(socket,
-      running: Bob.Queue.running(filter),
+      running: running,
       now: DateTime.utc_now(),
-      modules: modules,
+      modules: merge_modules(socket.assigns.modules, queued_counts, running),
       queued_counts: queued_counts,
       queue_total: queue_total,
       queued: Bob.Queue.queued_listing(@queued_page, socket.assigns.queued_offset, filter),
-      past: Bob.Queue.recent(@past_page, socket.assigns.past_offset, filter),
-      past_total: Bob.Queue.finished_count(filter),
+      past: Enum.take(past, @past_page),
+      past_more: length(past) > @past_page,
       loading: false
     )
+  end
+
+  defp load_modules() do
+    Bob.Queue.job_modules()
+    |> Enum.sort_by(&{housekeeping?(&1), module_name(&1)})
+  end
+
+  defp merge_modules(modules, queued_counts, running) do
+    seen = Map.keys(queued_counts) ++ Enum.map(running, & &1.module_key)
+
+    (modules ++ seen)
+    |> Enum.uniq()
+    |> Enum.sort_by(&{housekeeping?(&1), module_name(&1)})
   end
 
   defp schedule_tick(%{assigns: %{running: [], tick_scheduled: false}} = socket), do: socket
@@ -163,6 +179,8 @@ defmodule BobWeb.JobsLive do
 
   defp module_name(module_key), do: inspect(module_key)
 
+  defp chip_id(module_key), do: String.replace(module_name(module_key), ~r/[^A-Za-z0-9]+/, "-")
+
   defp module_label({module, key}), do: "#{inspect(module)} #{key}"
   defp module_label(module), do: inspect(module)
 
@@ -199,9 +217,10 @@ defmodule BobWeb.JobsLive do
         </div>
       </div>
 
-      <div :if={@modules != []} class="chip-row chip-row--filter">
+      <div :if={@modules != []} id="job-filters" class="chip-row chip-row--filter">
         <button
           :for={mod <- @modules}
+          id={"chip-" <> chip_id(mod)}
           type="button"
           class={["chip", MapSet.member?(@selected, module_name(mod)) && "chip--active"]}
           phx-click="toggle_module"
@@ -271,7 +290,7 @@ defmodule BobWeb.JobsLive do
         />
       </.section>
 
-      <.section title="Past" count={@past_total} icon="clock">
+      <.section title="Past" icon="clock">
         <div :if={@loading} class="empty-mini">Loading finished jobs...</div>
 
         <.table :if={!@loading and @past != []} rows={@past}>
@@ -299,7 +318,7 @@ defmodule BobWeb.JobsLive do
           count={length(@past)}
           page={@past_page}
           unit="jobs"
-          total={@past_total}
+          more={@past_more}
         />
       </.section>
     </div>

--- a/test/bob/queue/maintenance_test.exs
+++ b/test/bob/queue/maintenance_test.exs
@@ -113,4 +113,50 @@ defmodule Bob.Queue.MaintenanceTest do
 
     assert [%Job{state: "queued"}] = Repo.all(Job)
   end
+
+  test "caps completed job history at the maximum, keeping the most recent" do
+    Application.put_env(:bob, :history_max_jobs, 2)
+    on_exit(fn -> Application.delete_env(:bob, :history_max_jobs) end)
+
+    now = DateTime.utc_now()
+
+    for i <- 1..4 do
+      insert_job(state: "done", inserted_at: now, finished_at: DateTime.add(now, i, :second))
+    end
+
+    Maintenance.run()
+
+    kept =
+      Repo.all(from(j in Job, order_by: [asc: j.finished_at], select: j.finished_at))
+
+    assert kept == [DateTime.add(now, 3, :second), DateTime.add(now, 4, :second)]
+  end
+
+  test "does not count queued or running jobs toward the history cap" do
+    Application.put_env(:bob, :history_max_jobs, 2)
+    on_exit(fn -> Application.delete_env(:bob, :history_max_jobs) end)
+
+    now = DateTime.utc_now()
+    insert_job(state: "queued", args: [:q], args_digest: Term.digest([:q]), inserted_at: now)
+
+    insert_job(
+      state: "running",
+      args: [:r],
+      args_digest: Term.digest([:r]),
+      inserted_at: now,
+      started_at: now
+    )
+
+    for i <- 1..3 do
+      insert_job(state: "done", inserted_at: now, finished_at: DateTime.add(now, i, :second))
+    end
+
+    Maintenance.run()
+
+    assert Repo.all(Job) |> Enum.frequencies_by(& &1.state) == %{
+             "queued" => 1,
+             "running" => 1,
+             "done" => 2
+           }
+  end
 end

--- a/test/bob_web/live/jobs_live_test.exs
+++ b/test/bob_web/live/jobs_live_test.exs
@@ -24,7 +24,35 @@ defmodule BobWeb.JobsLiveTest do
     assert html =~ "OTPChecker"
     assert html =~ "done"
     assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>1<\/b>\s*queued\s*of\s*1 queued/
-    assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>1<\/b>\s*job\s*of\s*1 job/
+    assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>1<\/b>\s*job/
+    refute html =~ ~r/job\s*of\s*1 job/
+  end
+
+  test "pages past jobs without an exact total", %{conn: conn} do
+    # One more than the 50-row past page, so a second page exists.
+    for i <- 1..51 do
+      Bob.Queue.add(Bob.Job.OTPChecker, [i])
+      {:ok, {id, _}} = Bob.Queue.start(Bob.Job.OTPChecker)
+      Bob.Queue.success(id)
+    end
+
+    {:ok, view, html} = live(conn, ~p"/")
+
+    assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>50<\/b>\s*jobs/
+    refute html =~ "of 51"
+
+    assert has_element?(
+             view,
+             "button[phx-click='past_page'][phx-value-dir='next']:not([disabled])"
+           )
+
+    html =
+      view
+      |> element("button[phx-click='past_page'][phx-value-dir='next']")
+      |> render_click()
+
+    assert html =~ ~r/Showing\s*<b>51<\/b>\s*-\s*<b>51<\/b>\s*job/
+    assert has_element?(view, "button[phx-click='past_page'][phx-value-dir='next'][disabled]")
   end
 
   test "filters jobs by toggling module chips", %{conn: conn} do


### PR DESCRIPTION
Three independent fixes to the read-only web UI and queue maintenance:

- Cap finished job history at 10,000 rows. Done/failed jobs were only pruned
  by age (90 days), so the table could grow very large on a busy queue.
  Periodic maintenance now also trims to the 10k most-recently-finished jobs.
  Queued/running rows are never counted or deleted. Overridable via
  `config :bob, history_max_jobs: N`.

- Keep the jobs filter responsive. Every pill click and background refresh
  ran a COUNT over all done/failed jobs and a DISTINCT module_key scan, which
  serialized behind each other in the LiveView process and made pills lag or
  drop clicks. The module list is now computed once at mount and the Past
  pager uses limit+1 has-more instead of an exact COUNT, so only bounded,
  indexed queries run on the hot path.

- Align the Docker tags "or" separator and tag count, which were pinned to
  the top of the filter bar by `align-items: stretch`.