### PR TITLE
Fix job filtering crash on tuple module keys

### DIFF
--- a/lib/bob/queue.ex
+++ b/lib/bob/queue.ex
@@ -232,7 +232,18 @@ defmodule Bob.Queue do
   end
 
   defp filter_modules(query, []), do: query
-  defp filter_modules(query, modules), do: where(query, [j], j.module_key in ^modules)
+
+  defp filter_modules(query, modules) do
+    # A module key can be a `{module, key}` tuple, and a list of those reads as a
+    # keyword list, which Ecto's `in` rejects. Match each key with `==` so the
+    # Term type dumps it as a single value instead.
+    conditions =
+      Enum.reduce(modules, dynamic(false), fn module, acc ->
+        dynamic([j], ^acc or j.module_key == ^module)
+      end)
+
+    where(query, ^conditions)
+  end
 
   defp finish(id, state) do
     now = DateTime.utc_now()

--- a/test/bob/queue_test.exs
+++ b/test/bob/queue_test.exs
@@ -364,6 +364,24 @@ defmodule Bob.QueueTest do
       assert length(Queue.running([])) == 2
     end
 
+    test "filters by a list of only tuple module keys" do
+      key = {TestJob, :variant}
+      Queue.add(key, [:a])
+      Queue.add(Bob.Job.OTPChecker, [:b])
+
+      assert [j] = Queue.queued_listing(100, 0, [key])
+      assert j.module_key == key
+
+      {:ok, {id, _}} = Queue.start(key)
+      assert [r] = Queue.running([key])
+      assert r.module_key == key
+
+      Queue.success(id)
+      assert [p] = Queue.recent(50, 0, [key])
+      assert p.module_key == key
+      assert Queue.finished_count([key]) == 1
+    end
+
     test "recent/3 and finished_count/1 filter by module" do
       Queue.add(TestJob, [:a])
       {:ok, {id, _}} = Queue.start(TestJob)


### PR DESCRIPTION
A module key can be a `{module, key}` tuple (e.g. `{Bob.Job.BuildDockerErlang, "amd64"}`). Filtering the queue by such a key built `where: j.module_key in ^[{module, key}]`, and Ecto rejects a single-tuple list because it reads as a keyword list, raising `Ecto.QueryError`.

In the jobs UI, selecting one of those pills crashed the LiveView, which silently re-mounted and dropped the selection — so the filter appeared to do nothing. It only affected pills for tuple-keyed jobs (the build jobs that carry queue backlog), which is why it reproduced on production but not locally. Tracked in Sentry as BOB-27.

Match each key with `==` so the Term type dumps it as a single value instead of using `in` over a list.