### PR TITLE
Report outbound HTTP calls and which revision is running

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           platforms: linux/arm64
           tags: gcr.io/${{ env.PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}
+          build-args: |
+            GIT_SHA=${{ env.COMMIT_SHORT_SHA }}
+            GIT_AUTHOR=${{ github.event.head_commit.author.name }}
           push: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,3 +67,12 @@ USER nobody
 
 ENV HOME=/app
 ENV LANG=C.UTF-8
+# Declared here, in the last stage, so a new commit does not invalidate the
+# build cache for everything above it. PromEx reads these to report which
+# revision is running.
+# Defaulted, because PromEx treats an empty variable as present and would
+# label the metric with a blank rather than saying it is unknown.
+ARG GIT_SHA=unknown
+ARG GIT_AUTHOR=unknown
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_AUTHOR=${GIT_AUTHOR}

--- a/lib/bob/prom_ex.ex
+++ b/lib/bob/prom_ex.ex
@@ -9,7 +9,8 @@ defmodule Bob.PromEx do
       Plugins.Application,
       Plugins.Beam,
       {Plugins.Phoenix, router: BobWeb.Router, endpoint: BobWeb.Endpoint},
-      Bob.PromEx.Plugins.Bob
+      Bob.PromEx.Plugins.Bob,
+      Bob.PromEx.Plugins.OutboundHttp
     ] ++ master_plugins()
   end
 

--- a/lib/bob/prom_ex/plugins/outbound_http.ex
+++ b/lib/bob/prom_ex/plugins/outbound_http.ex
@@ -1,0 +1,101 @@
+defmodule Bob.PromEx.Plugins.OutboundHttp do
+  @moduledoc """
+  PromEx plugin for the HTTP calls this application makes.
+
+  Everything outbound goes through Finch, whether it is reached directly or
+  through a library layered on top of it, so instrumenting Finch covers all of
+  them without each library needing its own plugin.
+
+  Requests are tagged by host rather than by full URL, which keeps the number of
+  series bounded by the handful of services we talk to.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    metric_prefix =
+      Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :outbound_http))
+
+    Event.build(:bob_outbound_http_event_metrics, [
+      distribution(
+        metric_prefix ++ [:request, :duration, :milliseconds],
+        event_name: [:finch, :request, :stop],
+        measurement: :duration,
+        description: "How long an outbound HTTP request took.",
+        reporter_options: [buckets: [10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000]],
+        tags: [:host, :method, :status],
+        tag_values: &__MODULE__.request_tags/1,
+        unit: {:native, :millisecond}
+      ),
+      counter(
+        metric_prefix ++ [:request, :total],
+        event_name: [:finch, :request, :stop],
+        description: "Outbound HTTP requests that produced a response or an error.",
+        tags: [:host, :method, :status],
+        tag_values: &__MODULE__.request_tags/1
+      ),
+      counter(
+        metric_prefix ++ [:request, :exception, :total],
+        event_name: [:finch, :request, :exception],
+        description: "Outbound HTTP requests that raised.",
+        tags: [:host, :method, :kind],
+        tag_values: &__MODULE__.exception_tags/1
+      ),
+      distribution(
+        metric_prefix ++ [:queue, :duration, :milliseconds],
+        event_name: [:finch, :queue, :stop],
+        measurement: :duration,
+        description:
+          "How long a request waited for a connection from the pool. Sustained time here means the pool is too small.",
+        reporter_options: [buckets: [1, 5, 10, 50, 100, 250, 500, 1_000, 5_000]],
+        tags: [:host],
+        tag_values: &__MODULE__.pool_tags/1,
+        unit: {:native, :millisecond}
+      ),
+      distribution(
+        metric_prefix ++ [:connect, :duration, :milliseconds],
+        event_name: [:finch, :connect, :stop],
+        measurement: :duration,
+        description: "How long establishing a new connection took.",
+        reporter_options: [buckets: [1, 5, 10, 50, 100, 250, 500, 1_000, 5_000]],
+        tags: [:host],
+        tag_values: &__MODULE__.pool_tags/1,
+        unit: {:native, :millisecond}
+      )
+    ])
+  end
+
+  @doc false
+  def request_tags(%{request: request} = metadata) do
+    %{
+      host: request.host,
+      method: request.method,
+      status: status(Map.get(metadata, :result))
+    }
+  end
+
+  @doc false
+  def exception_tags(%{request: request} = metadata) do
+    %{
+      host: request.host,
+      method: request.method,
+      kind: Map.get(metadata, :kind, :error)
+    }
+  end
+
+  @doc false
+  def pool_tags(metadata) do
+    %{host: Map.get(metadata, :host, "unknown")}
+  end
+
+  # A request that never got a response is still worth counting, so failures are
+  # labelled rather than dropped.
+  defp status({:ok, %{status: status}}), do: status
+  defp status({:ok, _other}), do: "ok"
+  defp status({:error, %{__struct__: module}}), do: inspect(module)
+  defp status({:error, _other}), do: "error"
+  defp status(_), do: "unknown"
+end

--- a/test/bob/prom_ex/plugins/outbound_http_test.exs
+++ b/test/bob/prom_ex/plugins/outbound_http_test.exs
@@ -1,0 +1,41 @@
+defmodule Bob.PromEx.Plugins.OutboundHttpTest do
+  use ExUnit.Case, async: true
+
+  alias Bob.PromEx.Plugins.OutboundHttp
+
+  defp request(host \\ "s3.amazonaws.com", method \\ "GET") do
+    Finch.build(method, "https://#{host}/")
+  end
+
+  test "tags a response by host, method and status" do
+    tags = OutboundHttp.request_tags(%{request: request(), result: {:ok, %{status: 200}}})
+
+    assert tags == %{host: "s3.amazonaws.com", method: "GET", status: 200}
+  end
+
+  test "counts a failed request rather than dropping it" do
+    result = {:error, %Mint.TransportError{reason: :timeout}}
+    tags = OutboundHttp.request_tags(%{request: request(), result: result})
+
+    assert tags.status == "Mint.TransportError"
+  end
+
+  test "falls back when the result is not a response" do
+    assert OutboundHttp.request_tags(%{request: request(), result: nil}).status == "unknown"
+  end
+
+  test "attaches to the Finch events the requests actually emit" do
+    events =
+      [otp_app: :bob]
+      |> OutboundHttp.event_metrics()
+      |> List.wrap()
+      |> Enum.flat_map(& &1.metrics)
+      |> Enum.map(& &1.event_name)
+      |> Enum.uniq()
+
+    assert [:finch, :request, :stop] in events
+    assert [:finch, :request, :exception] in events
+    assert [:finch, :queue, :stop] in events
+    assert [:finch, :connect, :stop] in events
+  end
+end


### PR DESCRIPTION
Two gaps in what the applications report about themselves.

## Outbound HTTP

Nothing described the calls this application makes, so a slow dependency was indistinguishable from slow code. Everything outbound goes through Finch, whether reached directly or through a library layered on top of it, so a single plugin attached to Finch covers all of them rather than each library needing its own.

Reports request duration and count by host, method and status, exceptions, time spent waiting for a connection from the pool, and connection setup time. Tagged by host rather than URL so the series stay bounded by the handful of services we talk to. Failed requests are labelled with the error rather than dropped, so a dependency that stops responding is visible rather than merely absent.

## Git SHA and author

The Application dashboard panels for these read `Git SHA not available`, because PromEx takes them from the environment and nothing set it. They are now build arguments.

Declared in the final stage so a new commit does not invalidate the build cache for everything above it, and given defaults because PromEx uses `System.fetch_env`, which treats an empty variable as present — without a default a build made without the arguments would label the metric with a blank rather than saying it is unknown. Verified by building both ways.