### PR TITLE
Start PromEx before the repo

### DIFF
--- a/lib/bob/application.ex
+++ b/lib/bob/application.ex
@@ -11,10 +11,19 @@ defmodule Bob.Application do
 
     File.mkdir_p!(Bob.tmp_dir())
 
+    opts = [strategy: :one_for_one, name: Bob.Supervisor]
+    Supervisor.start_link(children(), opts)
+  end
+
+  @doc false
+  # PromEx has to start before the repo. Its Ecto plugin picks up the pool size,
+  # timeout and repo name from the telemetry event the repo emits once, when it
+  # starts, and the Ecto dashboard reads its repo dropdown from those.
+  def children() do
     children =
-      repo_children() ++
+      [Bob.PromEx] ++
+        repo_children() ++
         [
-          Bob.PromEx,
           {Finch, name: Bob.Finch},
           {Task.Supervisor, [name: Bob.Tasks]},
           {Phoenix.PubSub, name: Bob.PubSub},
@@ -27,10 +36,7 @@ defmodule Bob.Application do
           metrics_server_spec()
         ]
 
-    children = Enum.reject(children, &is_nil/1)
-
-    opts = [strategy: :one_for_one, name: Bob.Supervisor]
-    Supervisor.start_link(children, opts)
+    Enum.reject(children, &is_nil/1)
   end
 
   defp repo_children() do

--- a/test/bob/application_test.exs
+++ b/test/bob/application_test.exs
@@ -1,0 +1,10 @@
+defmodule Bob.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  test "PromEx starts before the repo so it sees the repo's init telemetry" do
+    children = Bob.Application.children()
+
+    assert Enum.find_index(children, &(&1 == Bob.PromEx)) <
+             Enum.find_index(children, &(&1 == Bob.Repo))
+  end
+end

--- a/test/bob/runner_test.exs
+++ b/test/bob/runner_test.exs
@@ -20,8 +20,22 @@ defmodule Bob.RunnerTest do
   setup do
     on_exit(fn ->
       case Process.whereis(Bob.Runner) do
-        nil -> :ok
-        pid -> Process.exit(pid, :kill)
+        nil ->
+          :ok
+
+        pid ->
+          # Process.exit only sends the signal, and the runner holds a registered
+          # name until it is really gone. Returning before then leaves the next
+          # test's start_link racing the name, which it loses as
+          # {:error, {:already_started, pid}}.
+          ref = Process.monitor(pid)
+          Process.exit(pid, :kill)
+
+          receive do
+            {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+          after
+            5_000 -> raise "the runner outlived the test that started it"
+          end
       end
     end)
 


### PR DESCRIPTION
Bob's Ecto dashboard has been empty since it went up. The repo dropdown reads its options from `bob_prom_ex_ecto_repo_init_status_info`, which PromEx's Ecto plugin builds from the telemetry event a repo emits once, as it starts. PromEx was supervised after the repo, so it missed the event and never exported the metric. With no option to select, every panel filtered on an empty repo and rendered nothing.

hexpm and hexpm_billing already start PromEx first, which is why their Ecto dashboards work.