### PR TITLE
Pace Docker Hub against its rolling window

### DIFF
--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -3,8 +3,8 @@ defmodule Bob.DockerHub do
 
   @dockerhub_url "https://hub.docker.com/"
 
-  # Caps re-attempts after a 429 so a permanently throttled IP can't loop forever;
-  # each attempt first feeds the limiter, which blocks until the window resets.
+  # Caps re-attempts after a 429 so a throttled account can't loop forever. Each
+  # attempt takes a slot, which the limiter holds until the budget recovers.
   @max_rate_limit_retries 20
 
   def auth(username, password) do
@@ -74,40 +74,42 @@ defmodule Bob.DockerHub do
   end
 
   @doc """
-  Sends `method` to `url` paced by the shared rate limiter: acquires a slot
-  (blocking until the window has budget), feeds the response back so the gate
-  tracks the limit, and waits out 429s up to the retry cap. Returns the final
-  non-429 result for the caller to match on. Every outcome reports to the
-  limiter — a response without usable rate headers, or a transport error,
-  releases the calibration probe's slot — so a failed request can't leave the
-  gate shut for every later caller.
+  Sends `method` to `url` paced by the shared rate limiter, and waits out 429s
+  up to the retry cap. Returns the final non-429 result for the caller to match
+  on.
+
+  A slot is taken per attempt rather than per call, so the retries `Bob.HTTP`
+  makes for a transport error or a 5xx are counted against the budget like any
+  other request. Every attempt reports back, so a failed one can't leave the
+  gate holding a slot that is never returned.
   """
   def paced_request(method, url), do: paced_request(method, url, 0)
 
   defp paced_request(method, url, attempts) do
-    RateLimiter.acquire()
-
     result =
       Bob.HTTP.retry(
         "DockerHub #{url}",
-        fn -> Bob.HTTP.request(method, url, headers(), "", recv_timeout: 20_000) end,
+        fn ->
+          RateLimiter.acquire()
+          result = Bob.HTTP.request(method, url, headers(), "", recv_timeout: 20_000)
+          report(result)
+          result
+        end,
         retry_rate_limit?: false
       )
 
     case result do
-      {:ok, 429, response_headers, _body} when attempts < @max_rate_limit_retries ->
-        RateLimiter.throttle(response_headers)
+      {:ok, 429, _response_headers, _body} when attempts < @max_rate_limit_retries ->
         paced_request(method, url, attempts + 1)
 
-      {:ok, _status, response_headers, _body} ->
-        RateLimiter.observe(response_headers)
-        result
-
-      {:error, _reason} ->
-        RateLimiter.observe([])
+      _other ->
         result
     end
   end
+
+  defp report({:ok, 429, response_headers, _body}), do: RateLimiter.throttle(response_headers)
+  defp report({:ok, _status, response_headers, _body}), do: RateLimiter.observe(response_headers)
+  defp report({:error, _reason}), do: RateLimiter.observe([])
 
   def headers() do
     if token = Application.get_env(:bob, :dockerhub_token) do

--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -4,8 +4,10 @@ defmodule Bob.DockerHub do
   @dockerhub_url "https://hub.docker.com/"
 
   # Caps re-attempts after a 429 so a throttled account can't loop forever. Each
-  # attempt takes a slot, which the limiter holds until the budget recovers.
-  @max_rate_limit_retries 20
+  # attempt takes a slot, which the limiter holds until the budget recovers, and
+  # Bob.HTTP.retry multiplies its own attempts on top, so a small number here
+  # already covers a window's worth of waiting.
+  @max_rate_limit_retries 5
 
   def auth(username, password) do
     url = @dockerhub_url <> "v2/users/login/"

--- a/lib/bob/docker_hub/rate_limiter.ex
+++ b/lib/bob/docker_hub/rate_limiter.ex
@@ -1,37 +1,35 @@
 defmodule Bob.DockerHub.RateLimiter do
   @moduledoc """
-  Process-wide gate that lets Docker Hub API requests burst up to the window's
-  limit, then waits for the window to reset. Docker Hub caps the tags API at 600
-  requests/minute per source IP and reports the budget in its `x-ratelimit-*`
-  headers.
+  Process-wide gate that paces Docker Hub API requests under the account's
+  budget.
 
-  The count is of **our own** granted requests, not the server's reported
-  `remaining` — that number lags the requests already in flight, so granting up
-  to it overshoots. `remaining` is used only to seed the count (so a window the
-  previous run partly spent is respected) and to ratchet it up if something
-  outside this process eats budget; it never lowers our own tally. The window is
-  reset on a timer derived from the `reset` header plus a small offset, so we
-  resume only after the server's window has actually rolled — not a beat before
-  it, when our clock runs slightly ahead of Docker Hub's.
+  Docker Hub meters a rolling window: `x-ratelimit-reset` is a moving estimate
+  of when the oldest request ages out, recomputed on every response, not a
+  boundary the count resets on. The gate keeps its own send times and admits
+  while fewer than `limit` of them fall in the trailing window, the model the
+  server applies.
 
-  A request sent before any response has anchored the window is the lone
-  calibration probe. The gate reclaims its slot if it reports a response
-  without usable rate headers, or dies without reporting at all, so a probe
-  that never anchors the window can't wedge every later caller behind it
-  forever.
+  The budget is metered per account rather than per source IP, so other nodes
+  spend it too. `x-ratelimit-remaining` carries that across them: when another
+  node spends, this one sees the budget fall and backs off, with no shared
+  state. It is read against the requests still in flight, which the server has
+  not counted yet, and dropped once it is older than the window it was taken in.
+
+  Every granted caller is monitored so one that dies without reporting gives its
+  slot back.
   """
 
   use GenServer
 
   require Logger
 
-  # Resume this long after the server's reset, so a local clock running slightly
-  # ahead of Docker Hub's can't send into the tail of the previous window.
-  @resume_offset_ms 2_000
+  # Docker Hub meters a rolling minute; our own sends are held for as long, so
+  # the trailing count lines up with what the server is counting.
+  @window_ms 60_000
 
-  # How long to hold the gate shut on a 429 that carries no usable rate headers,
-  # so callers stop hammering until the server's limit has had time to reset.
-  @throttle_fallback_ms 60_000
+  # How long the gate stays shut after a 429, giving the window time to move
+  # before the caller retries.
+  @park_ms 5_000
 
   def start_link(opts \\ []) do
     case Keyword.get(opts, :name, __MODULE__) do
@@ -40,29 +38,23 @@ defmodule Bob.DockerHub.RateLimiter do
     end
   end
 
-  @doc "Blocks until a request may be sent under the current window's budget."
+  @doc "Blocks until a request may be sent under the account's budget."
   def acquire(server \\ __MODULE__) do
     GenServer.call(server, :acquire, :infinity)
   end
 
   @doc """
-  Feeds a response's headers back so the gate tracks the limit and window.
-  Callers report every completed request, headers or not (`[]` for a transport
-  error): a report without usable rate headers releases the calibration
-  probe's slot when it comes from the probe itself, since that request
-  finished without anchoring the window.
+  Feeds a response's headers back so the gate tracks the budget and releases the
+  slot the caller took. Callers report every completed request, headers or not
+  (`[]` for a transport error).
   """
   def observe(headers, server \\ __MODULE__) do
     GenServer.cast(server, {:observe, parse_rate(headers), self()})
   end
 
-  @doc """
-  Feeds a 429 response back so the gate holds shut until the limit window
-  resets. If the response carries rate headers we anchor on their `reset`;
-  otherwise we fall back to a fixed wait.
-  """
+  @doc "Feeds a 429 back so the gate holds shut and stops the caller retrying into it."
   def throttle(headers, server \\ __MODULE__) do
-    GenServer.cast(server, {:throttle, parse_rate(headers)})
+    GenServer.cast(server, {:throttle, parse_rate(headers), self()})
   end
 
   @doc false
@@ -70,9 +62,8 @@ defmodule Bob.DockerHub.RateLimiter do
     headers = Map.new(headers, fn {key, value} -> {String.downcase(key), value} end)
 
     with {:ok, limit} <- fetch_int(headers, "x-ratelimit-limit"),
-         {:ok, remaining} <- fetch_int(headers, "x-ratelimit-remaining"),
-         {:ok, reset} <- fetch_int(headers, "x-ratelimit-reset") do
-      %{limit: limit, remaining: remaining, reset: reset}
+         {:ok, remaining} <- fetch_int(headers, "x-ratelimit-remaining") do
+      %{limit: limit, remaining: remaining}
     else
       _ -> nil
     end
@@ -82,204 +73,193 @@ defmodule Bob.DockerHub.RateLimiter do
   def init(opts) do
     {:ok,
      %{
-       sent: 0,
        limit: nil,
-       window: nil,
-       reset_at: nil,
-       offset_ms: Keyword.get(opts, :offset_ms, @resume_offset_ms),
+       remaining: nil,
+       measured_at: nil,
+       sends: :queue.new(),
+       in_flight: 0,
+       holders: %{},
+       parked_until: nil,
+       waiters: :queue.new(),
        timer: nil,
-       probe_mon: nil,
-       probe_pid: nil,
-       waiters: :queue.new()
+       window_ms: Keyword.get(opts, :window_ms, @window_ms),
+       park_ms: Keyword.get(opts, :park_ms, @park_ms),
+       clock: Keyword.get(opts, :clock, &__MODULE__.monotonic_ms/0)
      }}
   end
 
+  @doc false
+  def monotonic_ms(), do: System.monotonic_time(:millisecond)
+
   @impl true
   def handle_call(:acquire, from, state) do
-    state = roll(state)
+    state = expire(state)
 
     if available?(state) do
-      {:reply, :ok, grant(state, from)}
+      {:reply, :ok, grant(state, elem(from, 0))}
     else
-      {:noreply, schedule_resume(%{state | waiters: :queue.in(from, state.waiters)})}
+      {:noreply, schedule(%{state | waiters: :queue.in(from, state.waiters)})}
     end
   end
 
-  # The probe finished without usable rate headers, so nothing anchored the
-  # window: reclaim its slot the same way its death would, or the gate stays
-  # shut when the probe runs in a long-lived process.
   @impl true
-  def handle_cast({:observe, nil, pid}, %{probe_pid: pid} = state) do
-    {:noreply, schedule_resume(release(reclaim_probe(state)))}
+  def handle_cast({:observe, rate, pid}, state) do
+    state = state |> release_slot(pid) |> apply_rate(rate) |> expire()
+    {:noreply, schedule(admit(state))}
   end
 
-  def handle_cast({:observe, nil, _pid}, state), do: {:noreply, state}
+  def handle_cast({:throttle, rate, pid}, state) do
+    state = state |> release_slot(pid) |> apply_rate(rate) |> expire()
+    state = %{state | parked_until: state.clock.() + state.park_ms}
 
-  def handle_cast({:observe, rate, _pid}, state) do
-    state = apply_rate(state, rate)
-    state = if state.window != nil, do: clear_probe_mon(state), else: state
-    {:noreply, schedule_resume(release(state))}
-  end
+    Logger.warning(
+      "DockerHub rate limited, holding #{div(state.park_ms, 1000)}s before sending again"
+    )
 
-  # A 429 with rate headers reports remaining == 0, so apply_rate anchors the
-  # window with the count maxed out and the gate stays shut until it resets. No
-  # release: there is nothing to hand out.
-  def handle_cast({:throttle, rate}, state) when not is_nil(rate) do
-    state = clear_probe_mon(apply_rate(state, rate))
-    log_throttle(state)
-    {:noreply, schedule_resume(state)}
-  end
-
-  # A 429 without usable headers: hold the window shut for a fixed spell.
-  def handle_cast({:throttle, nil}, state) do
-    state = clear_probe_mon(park(state, @throttle_fallback_ms))
-    log_throttle(state)
-    {:noreply, schedule_resume(state)}
+    {:noreply, schedule(state)}
   end
 
   @impl true
-  def handle_info(:resume, state) do
-    {:noreply, schedule_resume(release(roll(%{state | timer: nil})))}
+  def handle_info(:wake, state) do
+    {:noreply, schedule(admit(expire(%{state | timer: nil})))}
   end
 
-  # The calibration probe died. If it never anchored the window, reclaim its
-  # slot and wake the next caller, so a probe that failed to report a response
-  # can't leave the gate shut with nothing left to roll or release it.
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{probe_mon: ref} = state) do
-    {:noreply, schedule_resume(release(reclaim_probe(state)))}
-  end
+  # A caller died mid-request and will never report, so return every slot it
+  # held.
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    state =
+      case state.holders do
+        %{^pid => {_ref, held}} ->
+          %{state | holders: Map.delete(state.holders, pid), in_flight: state.in_flight - held}
 
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
-    {:noreply, state}
-  end
-
-  # No confirmed window yet (cold start, or just rolled): allow a single probe
-  # so the next response anchors the real budget before we burst into it.
-  defp available?(%{window: nil, sent: sent}), do: sent < 1
-  defp available?(%{sent: sent, limit: limit}), do: sent < limit
-
-  # Hands a slot to `from`. While the window is unanchored the granted request is
-  # the lone calibration probe — monitor it so its termination can reclaim the
-  # slot if it dies without anchoring the window.
-  defp grant(state, from) do
-    state = %{state | sent: state.sent + 1}
-
-    if state.window == nil and state.probe_mon == nil do
-      pid = elem(from, 0)
-      %{state | probe_mon: Process.monitor(pid), probe_pid: pid}
-    else
-      state
-    end
-  end
-
-  # The probe finished without anchoring the window: give its slot back so the
-  # next caller becomes the new probe.
-  defp reclaim_probe(state) do
-    state = clear_probe_mon(state)
-    if state.window == nil, do: %{state | sent: max(state.sent - 1, 0)}, else: state
-  end
-
-  # Stop tracking the calibration probe once the window is anchored; its eventual
-  # exit no longer tells us anything.
-  defp clear_probe_mon(%{probe_mon: nil} = state), do: state
-
-  defp clear_probe_mon(%{probe_mon: ref} = state) do
-    Process.demonitor(ref, [:flush])
-    %{state | probe_mon: nil, probe_pid: nil}
-  end
-
-  # Folds a response's rate headers into the window: anchor it on the window's
-  # first response and seed the count from the server's usage; on later
-  # responses only ratchet the count up, never lower our own tally.
-  defp apply_rate(state, %{limit: limit, remaining: remaining, reset: reset}) do
-    state = %{state | limit: limit}
-
-    cond do
-      state.window == nil ->
-        %{
+        _ ->
           state
-          | window: reset,
-            reset_at: monotonic_deadline(reset) + state.offset_ms,
-            sent: max(state.sent, limit - remaining)
-        }
+      end
 
-      reset == state.window ->
-        %{state | sent: max(state.sent, limit - remaining)}
-
-      true ->
-        state
-    end
+    {:noreply, schedule(admit(expire(state)))}
   end
 
-  # Force the gate shut for `ms`, regardless of what the window thought it had.
-  defp park(state, ms) do
-    limit = state.limit || 1
+  # Until the budget has been measured, or once the measurement has aged out of
+  # the window, one request goes on its own to establish it.
+  defp available?(%{parked_until: parked}) when not is_nil(parked), do: false
+  defp available?(%{remaining: nil} = state), do: state.in_flight == 0
+
+  defp available?(state) do
+    :queue.len(state.sends) < state.limit and state.remaining > state.in_flight
+  end
+
+  defp grant(state, pid) do
+    holders =
+      case state.holders do
+        %{^pid => {ref, held}} -> Map.put(state.holders, pid, {ref, held + 1})
+        _ -> Map.put(state.holders, pid, {Process.monitor(pid), 1})
+      end
 
     %{
       state
-      | limit: limit,
-        sent: limit,
-        window: state.window || :throttled,
-        reset_at: System.monotonic_time(:millisecond) + ms + state.offset_ms
+      | sends: :queue.in(state.clock.(), state.sends),
+        in_flight: state.in_flight + 1,
+        holders: holders
     }
   end
 
-  # The window has elapsed (its reset plus the offset has passed): start the next
-  # one with a clean count. The next response re-anchors the window.
-  defp roll(%{reset_at: reset_at} = state) when not is_nil(reset_at) do
-    if System.monotonic_time(:millisecond) >= reset_at do
-      %{state | sent: 0, window: nil, reset_at: nil}
+  defp release_slot(state, pid) do
+    case state.holders do
+      %{^pid => {ref, 1}} ->
+        Process.demonitor(ref, [:flush])
+        %{state | holders: Map.delete(state.holders, pid), in_flight: state.in_flight - 1}
+
+      %{^pid => {ref, held}} ->
+        holders = Map.put(state.holders, pid, {ref, held - 1})
+        %{state | holders: holders, in_flight: state.in_flight - 1}
+
+      _ ->
+        state
+    end
+  end
+
+  # The newest reading wins, so a budget that has recovered is seen as recovered.
+  defp apply_rate(state, nil), do: state
+
+  defp apply_rate(state, %{limit: limit, remaining: remaining}) do
+    %{state | limit: limit, remaining: remaining, measured_at: state.clock.()}
+  end
+
+  # Ages out the sends that have left the window, the park, and a reading taken
+  # in a window that has since rolled.
+  defp expire(state) do
+    now = state.clock.()
+    cutoff = now - state.window_ms
+    stale? = state.measured_at != nil and state.measured_at <= cutoff
+
+    %{
+      state
+      | sends: drop_before(state.sends, cutoff),
+        parked_until: if(parked?(state.parked_until, now), do: state.parked_until),
+        remaining: if(stale?, do: nil, else: state.remaining),
+        measured_at: if(stale?, do: nil, else: state.measured_at)
+    }
+  end
+
+  defp parked?(nil, _now), do: false
+  defp parked?(parked_until, now), do: now < parked_until
+
+  defp drop_before(sends, cutoff) do
+    case :queue.peek(sends) do
+      {:value, at} when at <= cutoff -> sends |> :queue.drop() |> drop_before(cutoff)
+      _ -> sends
+    end
+  end
+
+  defp admit(state) do
+    if available?(state) and not :queue.is_empty(state.waiters) do
+      {{:value, from}, waiters} = :queue.out(state.waiters)
+      GenServer.reply(from, :ok)
+      admit(grant(%{state | waiters: waiters}, elem(from, 0)))
     else
       state
     end
   end
 
-  defp roll(state), do: state
+  # Wake at the next moment the gate could open on its own.
+  defp schedule(state) do
+    state = cancel_timer(state)
 
-  defp release(state) do
-    cond do
-      not available?(state) ->
-        state
-
-      :queue.is_empty(state.waiters) ->
-        state
-
-      true ->
-        {{:value, from}, waiters} = :queue.out(state.waiters)
-        GenServer.reply(from, :ok)
-        release(grant(%{state | waiters: waiters}, from))
-    end
-  end
-
-  # Wake at the window's reset so parked callers are released even when no further
-  # responses arrive to drive observe.
-  defp schedule_resume(%{timer: nil, reset_at: reset_at, waiters: waiters} = state)
-       when not is_nil(reset_at) do
-    if :queue.is_empty(waiters) do
-      state
+    with false <- :queue.is_empty(state.waiters),
+         at when not is_nil(at) <- wake_at(state) do
+      delay = max(at - state.clock.(), 0)
+      %{state | timer: Process.send_after(self(), :wake, delay)}
     else
-      delay = max(reset_at - System.monotonic_time(:millisecond), 0)
-      %{state | timer: Process.send_after(self(), :resume, delay)}
+      _ -> state
     end
   end
 
-  defp schedule_resume(state), do: state
+  defp wake_at(state) do
+    oldest_send =
+      case :queue.peek(state.sends) do
+        {:value, at} -> at + state.window_ms
+        :empty -> nil
+      end
 
-  defp log_throttle(%{reset_at: reset_at}) do
-    wait_s = div(max(reset_at - System.monotonic_time(:millisecond), 0), 1000)
-    Logger.warning("DockerHub rate limited, holding #{wait_s}s for the window to reset")
+    measurement = state.measured_at && state.measured_at + state.window_ms
+
+    [state.parked_until, oldest_send, measurement]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.min(fn -> nil end)
   end
 
-  defp monotonic_deadline(reset_unix) do
-    delay_ms = max(reset_unix - System.os_time(:second), 0) * 1000
-    System.monotonic_time(:millisecond) + delay_ms
+  defp cancel_timer(%{timer: nil} = state), do: state
+
+  defp cancel_timer(%{timer: timer} = state) do
+    Process.cancel_timer(timer)
+    %{state | timer: nil}
   end
 
   defp fetch_int(headers, key) do
     case headers do
       %{^key => value} ->
         case Integer.parse(value) do
-          {int, _} -> {:ok, int}
+          {int, _rest} -> {:ok, int}
           :error -> :error
         end
 

--- a/lib/bob/docker_hub/rate_limiter.ex
+++ b/lib/bob/docker_hub/rate_limiter.ex
@@ -5,31 +5,45 @@ defmodule Bob.DockerHub.RateLimiter do
 
   Docker Hub meters a rolling window: `x-ratelimit-reset` is a moving estimate
   of when the oldest request ages out, recomputed on every response, not a
-  boundary the count resets on. The gate keeps its own send times and admits
-  while fewer than `limit` of them fall in the trailing window, the model the
-  server applies.
+  boundary the count resets on. `x-ratelimit-remaining` is what the gate runs
+  on, read against the requests still in flight, which the server has not
+  counted yet. Because the budget is metered per account rather than per source
+  IP, that reading is also what carries other nodes' spending: when one spends,
+  the others see the budget fall and back off, with no shared state.
 
-  The budget is metered per account rather than per source IP, so other nodes
-  spend it too. `x-ratelimit-remaining` carries that across them: when another
-  node spends, this one sees the budget fall and backs off, with no shared
-  state. It is read against the requests still in flight, which the server has
-  not counted yet, and dropped once it is older than the window it was taken in.
+  A reading is a point measurement, but the budget it describes recovers
+  continuously, so between responses the gate carries it forward: sends made
+  since it was taken are subtracted, and sends that have since left the trailing
+  window are added back, because the server stops counting them at the same
+  moment. Without that the gate would have to wait out a whole window before it
+  believed in any recovery at all.
+
+  A reading older than the window is dropped, and until one exists the gate has
+  no measure of the budget: one request goes on its own to take one, with the
+  trailing count of its own sends held under `limit` so that a run of responses
+  carrying no usable rate headers cannot send unchecked.
 
   Every granted caller is monitored so one that dies without reporting gives its
-  slot back.
+  slot back, and a slot held longer than `max_hold_ms` is taken back regardless.
   """
 
   use GenServer
 
   require Logger
 
-  # Docker Hub meters a rolling minute; our own sends are held for as long, so
-  # the trailing count lines up with what the server is counting.
+  # Docker Hub meters a rolling minute. Our own sends are held for as long, and a
+  # reading is treated as describing that same window.
   @window_ms 60_000
 
-  # How long the gate stays shut after a 429, giving the window time to move
-  # before the caller retries.
+  # A floor on how long the gate stays shut after a 429. The reading taken from
+  # it normally holds the gate well past this on its own.
   @park_ms 5_000
+
+  # A slot is held from acquire until the caller reports. `receive_timeout`
+  # applies per receive, so a response that trickles holds one for as long as it
+  # keeps trickling, and this gate is a singleton: one wedged caller would stop
+  # every Docker Hub request on the node.
+  @max_hold_ms 120_000
 
   def start_link(opts \\ []) do
     case Keyword.get(opts, :name, __MODULE__) do
@@ -77,6 +91,10 @@ defmodule Bob.DockerHub.RateLimiter do
        remaining: nil,
        measured_at: nil,
        sends: :queue.new(),
+       sent_total: 0,
+       expired_total: 0,
+       sent_at_reading: 0,
+       expired_at_reading: 0,
        in_flight: 0,
        holders: %{},
        parked_until: nil,
@@ -84,6 +102,7 @@ defmodule Bob.DockerHub.RateLimiter do
        timer: nil,
        window_ms: Keyword.get(opts, :window_ms, @window_ms),
        park_ms: Keyword.get(opts, :park_ms, @park_ms),
+       max_hold_ms: Keyword.get(opts, :max_hold_ms, @max_hold_ms),
        clock: Keyword.get(opts, :clock, &__MODULE__.monotonic_ms/0)
      }}
   end
@@ -91,14 +110,16 @@ defmodule Bob.DockerHub.RateLimiter do
   @doc false
   def monotonic_ms(), do: System.monotonic_time(:millisecond)
 
+  # Queued behind any existing waiters rather than taking a slot that just
+  # opened, so a caller that arrives as the gate reopens cannot jump the queue.
   @impl true
   def handle_call(:acquire, from, state) do
     state = expire(state)
 
-    if available?(state) do
+    if :queue.is_empty(state.waiters) and available?(state) do
       {:reply, :ok, grant(state, elem(from, 0))}
     else
-      {:noreply, schedule(%{state | waiters: :queue.in(from, state.waiters)})}
+      {:noreply, schedule(admit(%{state | waiters: :queue.in(from, state.waiters)}))}
     end
   end
 
@@ -108,13 +129,15 @@ defmodule Bob.DockerHub.RateLimiter do
     {:noreply, schedule(admit(state))}
   end
 
+  # A 429 means the budget is spent whatever the response carried, so one
+  # without usable headers is read as zero. Leaving the previous reading in
+  # place would release a burst as soon as the park cleared.
   def handle_cast({:throttle, rate, pid}, state) do
+    rate = rate || %{limit: state.limit || 1, remaining: 0}
     state = state |> release_slot(pid) |> apply_rate(rate) |> expire()
     state = %{state | parked_until: state.clock.() + state.park_ms}
 
-    Logger.warning(
-      "DockerHub rate limited, holding #{div(state.park_ms, 1000)}s before sending again"
-    )
+    Logger.warning("DockerHub rate limited, holding until the window frees budget")
 
     {:noreply, schedule(state)}
   end
@@ -129,8 +152,12 @@ defmodule Bob.DockerHub.RateLimiter do
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     state =
       case state.holders do
-        %{^pid => {_ref, held}} ->
-          %{state | holders: Map.delete(state.holders, pid), in_flight: state.in_flight - held}
+        %{^pid => {_ref, holds}} ->
+          %{
+            state
+            | holders: Map.delete(state.holders, pid),
+              in_flight: state.in_flight - length(holds)
+          }
 
         _ ->
           state
@@ -139,25 +166,42 @@ defmodule Bob.DockerHub.RateLimiter do
     {:noreply, schedule(admit(expire(state)))}
   end
 
-  # Until the budget has been measured, or once the measurement has aged out of
-  # the window, one request goes on its own to establish it.
   defp available?(%{parked_until: parked}) when not is_nil(parked), do: false
-  defp available?(%{remaining: nil} = state), do: state.in_flight == 0
 
-  defp available?(state) do
-    :queue.len(state.sends) < state.limit and state.remaining > state.in_flight
+  # No reading to run on: one request goes on its own to take one, still bounded
+  # by the trailing count so a run of header-less responses cannot send
+  # unchecked.
+  defp available?(%{remaining: nil} = state) do
+    state.in_flight == 0 and within_window?(state)
   end
 
+  defp available?(state), do: credited_remaining(state) > state.in_flight
+
+  # Admitted against headroom the size of the in-flight set. Our sends are
+  # credited back when they leave our window, but the server counted them when
+  # it answered and drops them that much later, so crediting runs slightly ahead
+  # of the truth and the headroom absorbs it.
+  defp credited_remaining(state) do
+    state.remaining - (state.sent_total - state.sent_at_reading) +
+      (state.expired_total - state.expired_at_reading)
+  end
+
+  defp within_window?(%{limit: nil}), do: true
+  defp within_window?(state), do: :queue.len(state.sends) < state.limit
+
   defp grant(state, pid) do
+    now = state.clock.()
+
     holders =
       case state.holders do
-        %{^pid => {ref, held}} -> Map.put(state.holders, pid, {ref, held + 1})
-        _ -> Map.put(state.holders, pid, {Process.monitor(pid), 1})
+        %{^pid => {ref, holds}} -> Map.put(state.holders, pid, {ref, [now | holds]})
+        _ -> Map.put(state.holders, pid, {Process.monitor(pid), [now]})
       end
 
     %{
       state
-      | sends: :queue.in(state.clock.(), state.sends),
+      | sends: :queue.in(now, state.sends),
+        sent_total: state.sent_total + 1,
         in_flight: state.in_flight + 1,
         holders: holders
     }
@@ -165,13 +209,16 @@ defmodule Bob.DockerHub.RateLimiter do
 
   defp release_slot(state, pid) do
     case state.holders do
-      %{^pid => {ref, 1}} ->
+      %{^pid => {ref, [_only]}} ->
         Process.demonitor(ref, [:flush])
         %{state | holders: Map.delete(state.holders, pid), in_flight: state.in_flight - 1}
 
-      %{^pid => {ref, held}} ->
-        holders = Map.put(state.holders, pid, {ref, held - 1})
-        %{state | holders: holders, in_flight: state.in_flight - 1}
+      %{^pid => {ref, [_oldest | rest]}} ->
+        %{
+          state
+          | holders: Map.put(state.holders, pid, {ref, rest}),
+            in_flight: state.in_flight - 1
+        }
 
       _ ->
         state
@@ -182,42 +229,93 @@ defmodule Bob.DockerHub.RateLimiter do
   defp apply_rate(state, nil), do: state
 
   defp apply_rate(state, %{limit: limit, remaining: remaining}) do
-    %{state | limit: limit, remaining: remaining, measured_at: state.clock.()}
+    %{
+      state
+      | limit: limit,
+        remaining: remaining,
+        measured_at: state.clock.(),
+        sent_at_reading: state.sent_total,
+        expired_at_reading: state.expired_total
+    }
   end
 
-  # Ages out the sends that have left the window, the park, and a reading taken
-  # in a window that has since rolled.
+  # Ages out the sends that have left the window, the park, a reading taken in a
+  # window that has since rolled, and any slot held past the deadline.
   defp expire(state) do
     now = state.clock.()
     cutoff = now - state.window_ms
     stale? = state.measured_at != nil and state.measured_at <= cutoff
 
+    {sends, expired} = drop_before(state.sends, cutoff, 0)
+
     %{
       state
-      | sends: drop_before(state.sends, cutoff),
+      | sends: sends,
+        expired_total: state.expired_total + expired,
         parked_until: if(parked?(state.parked_until, now), do: state.parked_until),
         remaining: if(stale?, do: nil, else: state.remaining),
         measured_at: if(stale?, do: nil, else: state.measured_at)
     }
+    |> reap_holders(now)
   end
 
   defp parked?(nil, _now), do: false
   defp parked?(parked_until, now), do: now < parked_until
 
-  defp drop_before(sends, cutoff) do
+  defp reap_holders(state, now) do
+    deadline = now - state.max_hold_ms
+
+    Enum.reduce(state.holders, state, fn {pid, {ref, holds}}, acc ->
+      case Enum.reject(holds, &(&1 <= deadline)) do
+        ^holds ->
+          acc
+
+        kept ->
+          Logger.warning(
+            "DockerHub rate limiter reclaiming #{length(holds) - length(kept)} slot(s) " <>
+              "held past #{div(state.max_hold_ms, 1000)}s by #{inspect(pid)}"
+          )
+
+          acc = %{acc | in_flight: acc.in_flight - (length(holds) - length(kept))}
+
+          if kept == [] do
+            Process.demonitor(ref, [:flush])
+            %{acc | holders: Map.delete(acc.holders, pid)}
+          else
+            %{acc | holders: Map.put(acc.holders, pid, {ref, kept})}
+          end
+      end
+    end)
+  end
+
+  defp drop_before(sends, cutoff, dropped) do
     case :queue.peek(sends) do
-      {:value, at} when at <= cutoff -> sends |> :queue.drop() |> drop_before(cutoff)
-      _ -> sends
+      {:value, at} when at <= cutoff -> drop_before(:queue.drop(sends), cutoff, dropped + 1)
+      _ -> {sends, dropped}
     end
   end
 
+  # A waiter killed while queued would otherwise be handed a slot and counted
+  # against the window for nothing.
   defp admit(state) do
-    if available?(state) and not :queue.is_empty(state.waiters) do
-      {{:value, from}, waiters} = :queue.out(state.waiters)
-      GenServer.reply(from, :ok)
-      admit(grant(%{state | waiters: waiters}, elem(from, 0)))
-    else
-      state
+    cond do
+      :queue.is_empty(state.waiters) ->
+        state
+
+      not available?(state) ->
+        state
+
+      true ->
+        {{:value, from}, waiters} = :queue.out(state.waiters)
+        pid = elem(from, 0)
+        state = %{state | waiters: waiters}
+
+        if Process.alive?(pid) do
+          GenServer.reply(from, :ok)
+          admit(grant(state, pid))
+        else
+          admit(state)
+        end
     end
   end
 
@@ -241,9 +339,17 @@ defmodule Bob.DockerHub.RateLimiter do
         :empty -> nil
       end
 
-    measurement = state.measured_at && state.measured_at + state.window_ms
+    oldest_hold =
+      state.holders
+      |> Enum.flat_map(fn {_pid, {_ref, holds}} -> holds end)
+      |> Enum.min(fn -> nil end)
 
-    [state.parked_until, oldest_send, measurement]
+    [
+      state.parked_until,
+      oldest_send,
+      state.measured_at && state.measured_at + state.window_ms,
+      oldest_hold && oldest_hold + state.max_hold_ms
+    ]
     |> Enum.reject(&is_nil/1)
     |> Enum.min(fn -> nil end)
   end

--- a/test/bob/docker_hub/rate_limiter_test.exs
+++ b/test/bob/docker_hub/rate_limiter_test.exs
@@ -64,50 +64,17 @@ defmodule Bob.DockerHub.RateLimiterTest do
     end
   end
 
-  describe "the trailing window" do
-    test "admits up to the limit, then blocks" do
-      clock = new_clock()
-      limiter = start_limiter(clock)
-
-      for _ <- 1..5, do: take(limiter, headers(5, 5))
-
-      assert blocks?(limiter)
-    end
-
-    test "a send frees its slot only once it has left the window" do
-      clock = new_clock()
-      limiter = start_limiter(clock)
-
-      take(limiter, headers(5, 5))
-      advance(clock, 1_000)
-      for _ <- 1..4, do: take(limiter, headers(5, 5))
-
-      assert blocks?(limiter)
-
-      advance(clock, 58_999)
-      assert blocks?(limiter)
-
-      advance(clock, 1)
-      assert RateLimiter.acquire(limiter) == :ok
-    end
-
-    test "a slot reopens per send that ages out, not a whole budget at once" do
-      clock = new_clock()
-      limiter = start_limiter(clock)
-
-      take(limiter, headers(5, 5))
-      advance(clock, 55_000)
-      for _ <- 1..4, do: take(limiter, headers(5, 5))
-
-      advance(clock, 5_000)
-
-      assert RateLimiter.acquire(limiter) == :ok
-      assert blocks?(limiter)
-    end
-  end
-
   describe "the account budget" do
-    test "a remaining spent by another node closes the gate while our own window has room" do
+    test "admits while the budget lasts, then blocks" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      for remaining <- [4, 3, 2, 1, 0], do: take(limiter, headers(600, remaining))
+
+      assert blocks?(limiter)
+    end
+
+    test "a budget spent by another node closes the gate on this one" do
       clock = new_clock()
       limiter = start_limiter(clock)
 
@@ -118,18 +85,49 @@ defmodule Bob.DockerHub.RateLimiterTest do
       assert blocks?(limiter)
     end
 
-    test "remaining is read against the requests still in flight" do
+    test "the budget is admitted against headroom for the requests in flight" do
       clock = new_clock()
       limiter = start_limiter(clock)
 
       take(limiter, headers(600, 3))
 
-      # The server has not counted these yet, so they come off the reading.
-      for _ <- 1..3, do: assert(RateLimiter.acquire(limiter) == :ok)
+      # Three left on the reading, but each grant also has to clear the set the
+      # server has not answered yet, so the last one is held back.
+      for _ <- 1..2, do: assert(RateLimiter.acquire(limiter) == :ok)
 
       assert blocks?(limiter)
     end
 
+    test "a spent budget reopens once the reading has aged out of the window" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 0))
+      assert blocks?(limiter)
+
+      advance(clock, 59_999)
+      assert blocks?(limiter)
+
+      advance(clock, 1)
+      assert RateLimiter.acquire(limiter) == :ok
+    end
+
+    test "a recovered budget is seen as recovered" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 0))
+      assert blocks?(limiter)
+
+      advance(clock, 30_000)
+      RateLimiter.observe(headers(600, 500), limiter)
+      sync(limiter)
+
+      assert RateLimiter.acquire(limiter) == :ok
+    end
+  end
+
+  describe "the unmeasured path" do
     test "only one request goes until the budget has been measured" do
       clock = new_clock()
       limiter = start_limiter(clock)
@@ -141,6 +139,22 @@ defmodule Bob.DockerHub.RateLimiterTest do
       sync(limiter)
 
       assert RateLimiter.acquire(limiter) == :ok
+    end
+
+    test "responses without rate headers stay bounded by the trailing window" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(2, 2))
+      advance(clock, 60_000)
+
+      # Every response now comes back without usable rate headers, so no reading
+      # is ever established and `limit` plus the trailing sends are the only
+      # thing holding this down.
+      take(limiter, [])
+      take(limiter, [])
+
+      assert blocks?(limiter)
     end
 
     test "a reading older than the window is dropped and one request re-establishes it" do
@@ -166,7 +180,7 @@ defmodule Bob.DockerHub.RateLimiterTest do
   end
 
   describe "throttle/2" do
-    test "a 429 holds the gate shut until the park elapses" do
+    test "a 429 without rate headers is read as a spent budget" do
       clock = new_clock()
       limiter = start_limiter(clock, park_ms: 5_000)
 
@@ -177,11 +191,12 @@ defmodule Bob.DockerHub.RateLimiterTest do
 
       assert blocks?(limiter)
 
+      # The park alone would have released a burst against the pre-429 reading.
       advance(clock, 5_000)
-      assert RateLimiter.acquire(limiter) == :ok
+      assert blocks?(limiter)
     end
 
-    test "a 429 carrying a negative remaining keeps the gate shut past the park" do
+    test "a 429 carrying a budget holds the gate past the park" do
       clock = new_clock()
       limiter = start_limiter(clock, park_ms: 5_000)
 
@@ -195,17 +210,74 @@ defmodule Bob.DockerHub.RateLimiterTest do
     end
   end
 
-  describe "callers that die" do
+  describe "slots" do
     test "a caller that dies without reporting does not keep its slot" do
       clock = new_clock()
       limiter = start_limiter(clock)
 
-      take(limiter, headers(3, 3))
+      take(limiter, headers(600, 3))
 
       task = Task.async(fn -> RateLimiter.acquire(limiter) end)
       assert Task.await(task) == :ok
 
       assert eventually(fn -> sync(limiter).in_flight == 0 end)
+    end
+
+    test "a slot held past the deadline is taken back" do
+      clock = new_clock()
+      limiter = start_limiter(clock, max_hold_ms: 120_000)
+
+      take(limiter, headers(600, 2))
+
+      # A caller that never reports would otherwise hold this for good, and the
+      # gate is a singleton.
+      holder = spawn(fn -> Process.sleep(:infinity) end)
+      send(limiter, :wake)
+      assert RateLimiter.acquire(limiter) == :ok
+      assert sync(limiter).in_flight == 1
+
+      advance(clock, 120_000)
+      send(limiter, :wake)
+      assert sync(limiter).in_flight == 0
+
+      Process.exit(holder, :kill)
+    end
+
+    test "a waiter killed while queued is not handed a slot" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 0))
+
+      task = Task.async(fn -> RateLimiter.acquire(limiter) end)
+      assert Task.yield(task, 50) == nil
+      Task.shutdown(task, :brutal_kill)
+
+      before = :queue.len(sync(limiter).sends)
+
+      # The budget recovers; the corpse must not be handed one of the slots.
+      RateLimiter.observe(headers(600, 600), limiter)
+      sync(limiter)
+
+      assert :queue.len(sync(limiter).sends) == before
+    end
+
+    test "a caller arriving as the gate reopens does not jump the queue" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 0))
+
+      parent = self()
+      waiter = spawn(fn -> send(parent, {:admitted, RateLimiter.acquire(limiter)}) end)
+      assert eventually(fn -> :queue.len(sync(limiter).waiters) == 1 end)
+
+      advance(clock, 60_000)
+
+      assert RateLimiter.acquire(limiter) == :ok
+      assert_receive {:admitted, :ok}, 500
+
+      Process.exit(waiter, :kill)
     end
   end
 

--- a/test/bob/docker_hub/rate_limiter_test.exs
+++ b/test/bob/docker_hub/rate_limiter_test.exs
@@ -3,17 +3,34 @@ defmodule Bob.DockerHub.RateLimiterTest do
 
   alias Bob.DockerHub.RateLimiter
 
-  defp start_limiter(opts) do
-    {:ok, pid} = start_supervised({RateLimiter, [name: nil] ++ opts})
+  defp new_clock() do
+    {:ok, clock} = Agent.start_link(fn -> 0 end)
+    clock
+  end
+
+  defp advance(clock, ms), do: Agent.update(clock, &(&1 + ms))
+
+  defp start_limiter(clock, opts \\ []) do
+    opts = [name: nil, clock: fn -> Agent.get(clock, & &1) end, window_ms: 60_000] ++ opts
+    {:ok, pid} = start_supervised({RateLimiter, opts})
     pid
   end
 
-  defp headers(limit, remaining, reset) do
+  defp headers(limit, remaining) do
     [
       {"x-ratelimit-limit", Integer.to_string(limit)},
       {"x-ratelimit-remaining", Integer.to_string(remaining)},
-      {"x-ratelimit-reset", Integer.to_string(reset)}
+      {"x-ratelimit-reset", "1780736952"}
     ]
+  end
+
+  # observe/2 is a cast, so let it land before asserting on what follows.
+  defp sync(limiter), do: :sys.get_state(limiter)
+
+  defp take(limiter, headers) do
+    assert RateLimiter.acquire(limiter) == :ok
+    RateLimiter.observe(headers, limiter)
+    sync(limiter)
   end
 
   defp blocks?(limiter) do
@@ -24,19 +41,17 @@ defmodule Bob.DockerHub.RateLimiterTest do
   end
 
   describe "parse_rate/1" do
-    test "extracts the limit, remaining budget, and reset time" do
-      assert RateLimiter.parse_rate(headers(600, 396, 1_780_736_952)) ==
-               %{limit: 600, remaining: 396, reset: 1_780_736_952}
+    test "extracts the limit and the remaining budget" do
+      assert RateLimiter.parse_rate(headers(600, 396)) == %{limit: 600, remaining: 396}
     end
 
     test "matches header names case-insensitively" do
-      raw = [
-        {"X-RateLimit-Limit", "600"},
-        {"X-RateLimit-Remaining", "10"},
-        {"X-RateLimit-Reset", "1780736952"}
-      ]
+      raw = [{"X-RateLimit-Limit", "600"}, {"X-RateLimit-Remaining", "10"}]
+      assert RateLimiter.parse_rate(raw) == %{limit: 600, remaining: 10}
+    end
 
-      assert RateLimiter.parse_rate(raw) == %{limit: 600, remaining: 10, reset: 1_780_736_952}
+    test "keeps a negative remaining, which is how an overshoot is reported" do
+      assert RateLimiter.parse_rate(headers(600, -534)) == %{limit: 600, remaining: -534}
     end
 
     test "returns nil when the rate-limit headers are absent" do
@@ -44,166 +59,161 @@ defmodule Bob.DockerHub.RateLimiterTest do
     end
 
     test "returns nil when a value is not an integer" do
-      assert RateLimiter.parse_rate(headers(600, 600, 0) ++ [{"x-ratelimit-remaining", "lots"}]) ==
+      assert RateLimiter.parse_rate(headers(600, 600) ++ [{"x-ratelimit-remaining", "lots"}]) ==
                nil
     end
   end
 
-  describe "acquire/1 + observe/2" do
-    test "bursts the whole window immediately, then blocks" do
-      limiter = start_limiter(offset_ms: 0)
-      reset = System.os_time(:second) + 3600
+  describe "the trailing window" do
+    test "admits up to the limit, then blocks" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
 
-      RateLimiter.observe(headers(5, 5, reset), limiter)
-
-      for _ <- 1..5, do: assert(RateLimiter.acquire(limiter) == :ok)
-      assert blocks?(limiter)
-    end
-
-    test "allows a single calibration probe, then blocks until a response anchors the window" do
-      limiter = start_limiter(offset_ms: 0)
-      assert RateLimiter.acquire(limiter) == :ok
-      assert blocks?(limiter)
-    end
-
-    test "seeds the count from the server's reported usage" do
-      limiter = start_limiter(offset_ms: 0)
-      reset = System.os_time(:second) + 3600
-
-      # remaining 2 of 5 means 3 are already spent, so only 2 more are allowed.
-      RateLimiter.observe(headers(5, 2, reset), limiter)
-
-      assert RateLimiter.acquire(limiter) == :ok
-      assert RateLimiter.acquire(limiter) == :ok
-      assert blocks?(limiter)
-    end
-
-    test "ratchets the count up when external usage outruns ours" do
-      limiter = start_limiter(offset_ms: 0)
-      reset = System.os_time(:second) + 3600
-
-      RateLimiter.observe(headers(5, 5, reset), limiter)
-      assert RateLimiter.acquire(limiter) == :ok
-
-      # Same window now reports only 1 left (something else spent budget): the
-      # count jumps to 4, so just one more grant remains.
-      RateLimiter.observe(headers(5, 1, reset), limiter)
-      assert RateLimiter.acquire(limiter) == :ok
-      assert blocks?(limiter)
-    end
-
-    test "rolls to a fresh window once the reset has passed" do
-      limiter = start_limiter(offset_ms: 0)
-
-      # Window fully spent, but its reset is already in the past.
-      RateLimiter.observe(headers(5, 0, System.os_time(:second) - 1), limiter)
-
-      assert RateLimiter.acquire(limiter) == :ok
-    end
-
-    test "the offset holds the window past the server's stated reset" do
-      limiter = start_limiter(offset_ms: 60_000)
-
-      # Server says the window resets now, but the offset keeps us waiting.
-      RateLimiter.observe(headers(5, 0, System.os_time(:second)), limiter)
+      for _ <- 1..5, do: take(limiter, headers(5, 5))
 
       assert blocks?(limiter)
     end
 
-    test "releases a blocked caller when the window rolls" do
-      limiter = start_limiter(offset_ms: 100)
+    test "a send frees its slot only once it has left the window" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
 
-      RateLimiter.observe(headers(5, 0, System.os_time(:second)), limiter)
+      take(limiter, headers(5, 5))
+      advance(clock, 1_000)
+      for _ <- 1..4, do: take(limiter, headers(5, 5))
 
-      task = Task.async(fn -> RateLimiter.acquire(limiter) end)
-      assert Task.yield(task, 30) == nil
-      assert Task.await(task, 2000) == :ok
-    end
-
-    test "reclaims the probe slot when the probe dies without anchoring the window" do
-      limiter = start_limiter(offset_ms: 0)
-
-      # A caller takes the single calibration probe, then exits without ever
-      # reporting server headers (a non-2xx/429 response or a crash).
-      {pid, ref} = spawn_monitor(fn -> RateLimiter.acquire(limiter) end)
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
-
-      # Without reclaiming the dead probe's slot, the gate would stay shut
-      # forever: window unanchored, count stuck at one, nothing left to roll it.
-      assert RateLimiter.acquire(limiter) == :ok
-    end
-
-    test "reclaims the probe slot when the probe reports a response without rate headers" do
-      limiter = start_limiter(offset_ms: 0)
-
-      assert RateLimiter.acquire(limiter) == :ok
-
-      # The probe's request completed but carried no usable rate headers (a 401,
-      # a 5xx, or a transport error). Its slot is reclaimed even though the
-      # probe process lives on, so a long-lived caller can't wedge the gate.
-      RateLimiter.observe([], limiter)
-
-      refute blocks?(limiter)
-    end
-
-    test "ignores a headerless response from a caller that is not the probe" do
-      limiter = start_limiter(offset_ms: 0)
-      test_pid = self()
-
-      probe =
-        spawn_link(fn ->
-          RateLimiter.acquire(limiter)
-          send(test_pid, :granted)
-
-          receive do
-            :stop -> :ok
-          end
-        end)
-
-      assert_receive :granted
-
-      # A straggler that never held the probe slot reports a header-less
-      # response: the in-flight probe's slot must not be reclaimed on its behalf.
-      RateLimiter.observe([], limiter)
       assert blocks?(limiter)
 
-      send(probe, :stop)
+      advance(clock, 58_999)
+      assert blocks?(limiter)
+
+      advance(clock, 1)
+      assert RateLimiter.acquire(limiter) == :ok
     end
 
-    test "keeps the probe's slot when it anchored the window before exiting" do
-      limiter = start_limiter(offset_ms: 0)
-      reset = System.os_time(:second) + 3600
+    test "a slot reopens per send that ages out, not a whole budget at once" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
 
-      {pid, ref} =
-        spawn_monitor(fn ->
-          RateLimiter.acquire(limiter)
-          RateLimiter.observe(headers(2, 1, reset), limiter)
-        end)
+      take(limiter, headers(5, 5))
+      advance(clock, 55_000)
+      for _ <- 1..4, do: take(limiter, headers(5, 5))
 
-      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      advance(clock, 5_000)
 
-      # limit 2 with one already spent by the probe: exactly one grant remains.
       assert RateLimiter.acquire(limiter) == :ok
       assert blocks?(limiter)
     end
   end
 
-  describe "throttle/2" do
-    test "a 429 with rate headers holds the gate shut until the window resets" do
-      limiter = start_limiter(offset_ms: 0)
-      reset = System.os_time(:second) + 3600
+  describe "the account budget" do
+    test "a remaining spent by another node closes the gate while our own window has room" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
 
-      RateLimiter.throttle(headers(600, 0, reset), limiter)
+      take(limiter, headers(600, 600))
+      take(limiter, headers(600, 1))
+
+      assert RateLimiter.acquire(limiter) == :ok
+      assert blocks?(limiter)
+    end
+
+    test "remaining is read against the requests still in flight" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 3))
+
+      # The server has not counted these yet, so they come off the reading.
+      for _ <- 1..3, do: assert(RateLimiter.acquire(limiter) == :ok)
 
       assert blocks?(limiter)
     end
 
-    test "a 429 without rate headers holds the gate shut on the fallback window" do
-      limiter = start_limiter(offset_ms: 0)
+    test "only one request goes until the budget has been measured" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
 
-      RateLimiter.throttle([{"retry-after", "30"}], limiter)
+      assert RateLimiter.acquire(limiter) == :ok
+      assert blocks?(limiter)
+
+      RateLimiter.observe(headers(5, 5), limiter)
+      sync(limiter)
+
+      assert RateLimiter.acquire(limiter) == :ok
+    end
+
+    test "a reading older than the window is dropped and one request re-establishes it" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 600))
+      advance(clock, 60_000)
+
+      assert RateLimiter.acquire(limiter) == :ok
+      assert blocks?(limiter)
+    end
+
+    test "a response without rate headers releases the slot without changing the budget" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(600, 600))
+      take(limiter, [])
+
+      assert %{remaining: 600, in_flight: 0} = sync(limiter)
+    end
+  end
+
+  describe "throttle/2" do
+    test "a 429 holds the gate shut until the park elapses" do
+      clock = new_clock()
+      limiter = start_limiter(clock, park_ms: 5_000)
+
+      take(limiter, headers(600, 600))
+
+      RateLimiter.throttle([], limiter)
+      sync(limiter)
 
       assert blocks?(limiter)
+
+      advance(clock, 5_000)
+      assert RateLimiter.acquire(limiter) == :ok
+    end
+
+    test "a 429 carrying a negative remaining keeps the gate shut past the park" do
+      clock = new_clock()
+      limiter = start_limiter(clock, park_ms: 5_000)
+
+      take(limiter, headers(600, 600))
+
+      RateLimiter.throttle(headers(600, -534), limiter)
+      sync(limiter)
+
+      advance(clock, 5_000)
+      assert blocks?(limiter)
+    end
+  end
+
+  describe "callers that die" do
+    test "a caller that dies without reporting does not keep its slot" do
+      clock = new_clock()
+      limiter = start_limiter(clock)
+
+      take(limiter, headers(3, 3))
+
+      task = Task.async(fn -> RateLimiter.acquire(limiter) end)
+      assert Task.await(task) == :ok
+
+      assert eventually(fn -> sync(limiter).in_flight == 0 end)
+    end
+  end
+
+  defp eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() -> true
+      attempts == 0 -> false
+      true -> Process.sleep(10) && eventually(fun, attempts - 1)
     end
   end
 end


### PR DESCRIPTION
`x-ratelimit-reset` is not a window boundary. It is recomputed on every response as roughly now+58s, an estimate of when the oldest request ages out. Probing the delete endpoint at one request every 2.2s held `remaining` flat at 573 for 85 seconds rather than sawtoothing back to 600, which is a rolling minute.

`apply_rate/2` gated on `reset == state.window`, so once the first response of a window had landed that comparison stopped matching and every later reading of `remaining` was discarded. What was left was a fixed-window model: burst the whole limit, park until the anchor elapsed, burst again. Against a rolling counter the second burst lands while the first is still inside the window, which is how `remaining` reached -534 in production.

The gate now keeps its own send times and admits while fewer than `limit` of them fall in the trailing window, the model the server applies, so slots free one at a time as sends age out.

The budget is metered per account, not per source IP. A node deleting at 27 requests/minute took 56 429s in 92 requests while another node burst from a different IP, both reporting distinct `x-ratelimit-ip` values. Reading `remaining` on every response is what carries that between nodes, so one backs off when another spends, with no shared state. It is read against the requests still in flight, which the server has not counted, and dropped once older than the window it was taken in.

A 429 now parks the gate. It previously fed through the same reset mismatch and did nothing, so `paced_request` re-acquired immediately from a limiter that still believed it had budget, up to 20 times per request.

Slots are taken per HTTP attempt rather than per call, so the retries `Bob.HTTP` makes for a transport error or a 5xx count against the budget too. Every granted caller is monitored so one that dies without reporting gives its slot back.

This paces the Reconcile pager as well as the tag cleanup.