### PR TITLE
Clean up the erlang per-arch repos too

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -513,7 +513,7 @@ defmodule Bob.Artifacts do
   defp reserved_targets() do
     from(br in BuildRequest, where: br.state in ["pending", "completed"])
     |> Repo.all()
-    |> Enum.map(&BuildRequest.target/1)
+    |> Enum.flat_map(&BuildRequest.targets/1)
   end
 
   defp reserved(query), do: where(query, [d], d.tag in ^reserved_targets())
@@ -527,17 +527,30 @@ defmodule Bob.Artifacts do
     |> keep_current_erlang(current_os_versions)
   end
 
+  # An empty list means the build matrix could not be read, which protects every
+  # erlang tag. `<> ALL('{}')` is true, so leaving this to the general clause
+  # would delete the lot.
+  defp keep_current_erlang(query, []) do
+    where(query, [d], d.repo not in ^@erlang_arch_repos)
+  end
+
   # An erlang per-arch tag on one of the os_versions the build matrix currently
   # targets is kept whatever its age. DockerChecker.expected_elixir_tags/0 reads
   # those rows to decide which Elixir images to build and ranks them by version,
   # not by date, so the newest tag of an old OTP line stays in use indefinitely.
-  # A row whose search metadata carries no os_version is kept too.
+  # A tag whose metadata carries no os_version is kept, spelled out rather than
+  # left to `NULL <> ALL(...)` returning NULL.
   defp keep_current_erlang(query, current_os_versions) do
     where(
       query,
       [d],
       d.repo not in ^@erlang_arch_repos or
-        fragment("?->>'os_version' <> ALL(?)", d.search, ^current_os_versions)
+        fragment(
+          "?->>'os_version' IS NOT NULL AND ?->>'os_version' <> ALL(?)",
+          d.search,
+          d.search,
+          ^current_os_versions
+        )
     )
   end
 
@@ -563,8 +576,8 @@ defmodule Bob.Artifacts do
   @doc """
   The subset of `repo_tags` still deletable: present, older than `cutoff`,
   unreserved and not an erlang tag the build matrix still targets. Re-checked
-  per chunk because a run is slow enough for a tag to get reserved, re-pushed,
-  or pulled into the matrix by a base image release while it works.
+  per chunk because a run is slow enough for a tag to get reserved or re-pushed
+  while it works.
   """
   def deletable_docker_tags([], _cutoff, _current_os_versions), do: []
 

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -18,9 +18,8 @@ defmodule Bob.Artifacts do
   # wraps.
   @long_query_timeout 5 * 60 * 1000
 
-  # Elixir only. DockerChecker.expected_elixir_tags/0 derives the Elixir build
-  # matrix from the erlang per-arch rows, so pruning those stops Elixir builds.
-  @docker_cleanup_per_arch_repos ~w(hexpm/elixir-amd64 hexpm/elixir-arm64)
+  @erlang_arch_repos ~w(hexpm/erlang-amd64 hexpm/erlang-arm64)
+  @docker_cleanup_per_arch_repos ~w(hexpm/elixir-amd64 hexpm/elixir-arm64) ++ @erlang_arch_repos
 
   def add(attrs) do
     upsert(attrs)
@@ -525,15 +524,30 @@ defmodule Bob.Artifacts do
 
   # Only the known per-arch repos, so a caller cannot point the cleanup at a
   # manifest repo.
-  defp stale_per_arch(cutoff, repos) do
+  defp stale_per_arch(cutoff, repos, current_os_versions) do
     repos = Enum.filter(@docker_cleanup_per_arch_repos, &(&1 in repos))
 
     from(d in DockerTag, where: d.repo in ^repos and d.built_at < ^cutoff)
+    |> keep_current_erlang(current_os_versions)
+  end
+
+  # An erlang per-arch tag on one of the os_versions the build matrix currently
+  # targets is kept whatever its age. DockerChecker.expected_elixir_tags/0 reads
+  # those rows to decide which Elixir images to build and ranks them by version,
+  # not by date, so the newest tag of an old OTP line stays in use indefinitely.
+  # A row whose search metadata carries no os_version is kept too.
+  defp keep_current_erlang(query, current_os_versions) do
+    where(
+      query,
+      [d],
+      d.repo not in ^@erlang_arch_repos or
+        fragment("?->>'os_version' <> ALL(?)", d.search, ^current_os_versions)
+    )
   end
 
   @doc "Per-repo count of the tags a run would delete."
-  def count_stale_per_arch_tags(cutoff, repos \\ @docker_cleanup_per_arch_repos) do
-    stale_per_arch(cutoff, repos)
+  def count_stale_per_arch_tags(cutoff, repos, current_os_versions) do
+    stale_per_arch(cutoff, repos, current_os_versions)
     |> unreserved()
     |> group_by([d], d.repo)
     |> select([d], {d.repo, count(d.id)})
@@ -542,8 +556,8 @@ defmodule Bob.Artifacts do
   end
 
   @doc "Up to `limit` deletable `{repo, tag}` pairs."
-  def stale_per_arch_tags(cutoff, limit, repos \\ @docker_cleanup_per_arch_repos) do
-    stale_per_arch(cutoff, repos)
+  def stale_per_arch_tags(cutoff, limit, repos, current_os_versions) do
+    stale_per_arch(cutoff, repos, current_os_versions)
     |> unreserved()
     |> limit(^limit)
     |> select([d], {d.repo, d.tag})
@@ -551,13 +565,14 @@ defmodule Bob.Artifacts do
   end
 
   @doc """
-  The subset of `repo_tags` still deletable: present, older than `cutoff` and
-  unreserved. Re-checked per chunk because a run is slow enough for a tag to get
-  reserved or re-pushed while it works.
+  The subset of `repo_tags` still deletable: present, older than `cutoff`,
+  unreserved and not an erlang tag the build matrix still targets. Re-checked
+  per chunk because a run is slow enough for a tag to get reserved, re-pushed,
+  or pulled into the matrix by a base image release while it works.
   """
-  def deletable_docker_tags([], _cutoff), do: []
+  def deletable_docker_tags([], _cutoff, _current_os_versions), do: []
 
-  def deletable_docker_tags(repo_tags, cutoff) do
+  def deletable_docker_tags(repo_tags, cutoff, current_os_versions) do
     {repos, tags} = Enum.unzip(repo_tags)
     wanted = MapSet.new(repo_tags)
 
@@ -567,6 +582,7 @@ defmodule Bob.Artifacts do
       select: {d.repo, d.tag}
     )
     |> unreserved()
+    |> keep_current_erlang(current_os_versions)
     |> Repo.all(timeout: @long_query_timeout)
     # The two `in` clauses match a cross product, so drop pairs not asked for.
     |> Enum.filter(&MapSet.member?(wanted, &1))

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -520,14 +520,10 @@ defmodule Bob.Artifacts do
 
   defp unreserved(query), do: where(query, [d], d.tag not in ^reserved_targets())
 
-  def docker_cleanup_per_arch_repos(), do: @docker_cleanup_per_arch_repos
-
-  # Only the known per-arch repos, so a caller cannot point the cleanup at a
-  # manifest repo.
-  defp stale_per_arch(cutoff, repos, current_os_versions) do
-    repos = Enum.filter(@docker_cleanup_per_arch_repos, &(&1 in repos))
-
-    from(d in DockerTag, where: d.repo in ^repos and d.built_at < ^cutoff)
+  defp stale_per_arch(cutoff, current_os_versions) do
+    from(d in DockerTag,
+      where: d.repo in ^@docker_cleanup_per_arch_repos and d.built_at < ^cutoff
+    )
     |> keep_current_erlang(current_os_versions)
   end
 
@@ -546,8 +542,8 @@ defmodule Bob.Artifacts do
   end
 
   @doc "Per-repo count of the tags a run would delete."
-  def count_stale_per_arch_tags(cutoff, repos, current_os_versions) do
-    stale_per_arch(cutoff, repos, current_os_versions)
+  def count_stale_per_arch_tags(cutoff, current_os_versions) do
+    stale_per_arch(cutoff, current_os_versions)
     |> unreserved()
     |> group_by([d], d.repo)
     |> select([d], {d.repo, count(d.id)})
@@ -556,8 +552,8 @@ defmodule Bob.Artifacts do
   end
 
   @doc "Up to `limit` deletable `{repo, tag}` pairs."
-  def stale_per_arch_tags(cutoff, limit, repos, current_os_versions) do
-    stale_per_arch(cutoff, repos, current_os_versions)
+  def stale_per_arch_tags(cutoff, limit, current_os_versions) do
+    stale_per_arch(cutoff, current_os_versions)
     |> unreserved()
     |> limit(^limit)
     |> select([d], {d.repo, d.tag})

--- a/lib/bob/build_requests/build_request.ex
+++ b/lib/bob/build_requests/build_request.ex
@@ -33,4 +33,15 @@ defmodule Bob.BuildRequests.BuildRequest do
   def target(%{kind: "elixir"} = request) do
     "#{request.elixir}-erlang-#{request.erlang}-#{request.os}-#{request.os_version}"
   end
+
+  @doc """
+  Every tag a request holds. An elixir image is built FROM the erlang image for
+  the same OTP and OS, so the base is reserved alongside it: expiring a request
+  leaves its build queued, and the base has to outlive that job.
+  """
+  def targets(%{kind: "erlang"} = request), do: [target(request)]
+
+  def targets(%{kind: "elixir"} = request) do
+    [target(request), "#{request.erlang}-#{request.os}-#{request.os_version}"]
+  end
 end

--- a/lib/bob/docker_cleanup.ex
+++ b/lib/bob/docker_cleanup.ex
@@ -13,8 +13,8 @@ defmodule Bob.DockerCleanup do
 
   alias Bob.Artifacts
 
-  # Must stay >= Bob.Job.DockerChecker.build_freshness_days/0 or cleanup deletes
-  # tags the checker still expects. Asserted in docker_cleanup_test.
+  # Must stay >= the DockerChecker build freshness window or cleanup deletes
+  # tags that pass still expects.
   @per_arch_max_age_days 30
 
   # Candidate query page size.
@@ -54,12 +54,13 @@ defmodule Bob.DockerCleanup do
     limit = Keyword.get(opts, :limit, @default_batch)
     cutoff = per_arch_cutoff()
 
+    # Pinned for the whole run, like the cutoff. A base image released mid-run
+    # rotates the os_version it replaces out of the matrix, and the erlang tags
+    # on it must stay protected until the checker has built their replacements.
+    os_versions = current_os_versions()
+
     deleted =
       Stream.repeatedly(fn ->
-        # Re-read per batch so a base image released mid-run pulls the erlang
-        # tags built against it back under protection.
-        os_versions = current_os_versions()
-
         cutoff
         |> Artifacts.stale_per_arch_tags(limit, os_versions)
         |> delete(deleter, cutoff, os_versions)

--- a/lib/bob/docker_cleanup.ex
+++ b/lib/bob/docker_cleanup.ex
@@ -1,15 +1,17 @@
 defmodule Bob.DockerCleanup do
   @moduledoc """
   Deletes per-arch Docker Hub tags older than 30 days. Tags reserved by a build
-  request are kept. The manifest repos are not pruned.
+  request are kept, as are the erlang tags on an os_version the build matrix
+  still targets. The manifest repos are not pruned.
 
   A live run keeps taking batches until one deletes nothing, so it clears the
   whole backlog rather than a single batch. What bounds it is the job's timeout.
   `:docker_cleanup_mode` gates whether it deletes or only reports.
 
-  `:repos` narrows a run to some of the per-arch repos. Docker Hub rate limits
-  deletes per source IP, so pointing one node at each repo doubles throughput,
-  where two nodes on the same repo just race for the same tags.
+  `:repos` narrows a run to some of the per-arch repos. Docker Hub meters the
+  API per account rather than per source IP, so a second node deleting at the
+  same time draws down the same budget: the two together get no more through
+  than one does, and spend the difference on 429s. Run one at a time.
   """
 
   require Logger
@@ -44,7 +46,9 @@ defmodule Bob.DockerCleanup do
   defp configured_mode(), do: Application.get_env(:bob, :docker_cleanup_mode, :dry_run)
 
   defp dry_run(repos) do
-    per_arch = Artifacts.count_stale_per_arch_tags(per_arch_cutoff(), repos)
+    per_arch =
+      Artifacts.count_stale_per_arch_tags(per_arch_cutoff(), repos, current_os_versions())
+
     backlog = per_arch |> Map.values() |> Enum.sum()
 
     # The backlog is every candidate; a scheduled run stops at the batch.
@@ -64,9 +68,13 @@ defmodule Bob.DockerCleanup do
 
     deleted =
       Stream.repeatedly(fn ->
+        # Re-read per batch so a base image released mid-run pulls the erlang
+        # tags built against it back under protection.
+        os_versions = current_os_versions()
+
         cutoff
-        |> Artifacts.stale_per_arch_tags(limit, repos)
-        |> delete(deleter, cutoff)
+        |> Artifacts.stale_per_arch_tags(limit, repos, os_versions)
+        |> delete(deleter, cutoff, os_versions)
       end)
       |> Enum.reduce_while(0, fn batch, total ->
         if batch == 0, do: {:halt, total}, else: {:cont, total + batch}
@@ -79,11 +87,11 @@ defmodule Bob.DockerCleanup do
   # Deleted rows are dropped only after Docker Hub confirms, so a failed tag is
   # retried next run. Candidates are re-checked per chunk because a run is slow
   # enough for a tag to get reserved or re-pushed while it works.
-  defp delete(candidates, deleter, cutoff) do
+  defp delete(candidates, deleter, cutoff, os_versions) do
     candidates
     |> Enum.chunk_every(@delete_chunk)
     |> Enum.reduce_while({0, 0}, fn chunk, {deleted, dead_chunks} ->
-      {confirmed, failed} = delete_chunk(chunk, deleter, cutoff)
+      {confirmed, failed} = delete_chunk(chunk, deleter, cutoff, os_versions)
       Artifacts.delete_docker_tags(confirmed)
       deleted = deleted + length(confirmed)
 
@@ -104,9 +112,9 @@ defmodule Bob.DockerCleanup do
     |> elem(0)
   end
 
-  defp delete_chunk(chunk, deleter, cutoff) do
+  defp delete_chunk(chunk, deleter, cutoff, os_versions) do
     chunk
-    |> Artifacts.deletable_docker_tags(cutoff)
+    |> Artifacts.deletable_docker_tags(cutoff, os_versions)
     |> Task.async_stream(
       fn {repo, tag} ->
         case deleter.(repo, tag) do
@@ -130,6 +138,8 @@ defmodule Bob.DockerCleanup do
   end
 
   defp per_arch_cutoff(), do: DateTime.add(DateTime.utc_now(), -@per_arch_max_age_days, :day)
+
+  defp current_os_versions(), do: Bob.Job.DockerChecker.current_os_versions()
 
   defp format_counts(counts) do
     total = counts |> Map.values() |> Enum.sum()

--- a/lib/bob/docker_cleanup.ex
+++ b/lib/bob/docker_cleanup.ex
@@ -7,11 +7,6 @@ defmodule Bob.DockerCleanup do
   A live run keeps taking batches until one deletes nothing, so it clears the
   whole backlog rather than a single batch. What bounds it is the job's timeout.
   `:docker_cleanup_mode` gates whether it deletes or only reports.
-
-  `:repos` narrows a run to some of the per-arch repos. Docker Hub meters the
-  API per account rather than per source IP, so a second node deleting at the
-  same time draws down the same budget: the two together get no more through
-  than one does, and spend the difference on 429s. Run one at a time.
   """
 
   require Logger
@@ -35,33 +30,26 @@ defmodule Bob.DockerCleanup do
   @default_concurrency 25
 
   def run(opts \\ []) do
-    repos = Keyword.get(opts, :repos, Artifacts.docker_cleanup_per_arch_repos())
-
     case Keyword.get(opts, :mode, configured_mode()) do
-      :dry_run -> dry_run(repos)
-      :live -> live(opts, repos)
+      :dry_run -> dry_run()
+      :live -> live(opts)
     end
   end
 
   defp configured_mode(), do: Application.get_env(:bob, :docker_cleanup_mode, :dry_run)
 
-  defp dry_run(repos) do
-    per_arch =
-      Artifacts.count_stale_per_arch_tags(per_arch_cutoff(), repos, current_os_versions())
+  defp dry_run() do
+    per_arch = Artifacts.count_stale_per_arch_tags(per_arch_cutoff(), current_os_versions())
 
-    backlog = per_arch |> Map.values() |> Enum.sum()
-
-    # The backlog is every candidate; a scheduled run stops at the batch.
     Logger.info(
       "DOCKER CLEANUP dry-run: per-arch built_at < #{@per_arch_max_age_days}d -> " <>
-        "#{format_counts(per_arch)}; one scheduled run would delete " <>
-        "#{min(backlog, @default_batch)} of them (batch #{@default_batch})"
+        format_counts(per_arch)
     )
 
     {:dry_run, %{per_arch: per_arch}}
   end
 
-  defp live(opts, repos) do
+  defp live(opts) do
     deleter = Keyword.get(opts, :deleter, &Bob.DockerHub.delete_tag/2)
     limit = Keyword.get(opts, :limit, @default_batch)
     cutoff = per_arch_cutoff()
@@ -73,14 +61,14 @@ defmodule Bob.DockerCleanup do
         os_versions = current_os_versions()
 
         cutoff
-        |> Artifacts.stale_per_arch_tags(limit, repos, os_versions)
+        |> Artifacts.stale_per_arch_tags(limit, os_versions)
         |> delete(deleter, cutoff, os_versions)
       end)
       |> Enum.reduce_while(0, fn batch, total ->
         if batch == 0, do: {:halt, total}, else: {:cont, total + batch}
       end)
 
-    Logger.info("DOCKER CLEANUP deleted #{deleted} tag(s) from #{Enum.join(repos, ", ")}")
+    Logger.info("DOCKER CLEANUP deleted #{deleted} tag(s)")
     {:live, deleted}
   end
 
@@ -128,7 +116,7 @@ defmodule Bob.DockerCleanup do
       end,
       max_concurrency: @default_concurrency,
       ordered: false,
-      # The limiter can park a caller until its window resets.
+      # The limiter can hold a caller until the budget recovers.
       timeout: :infinity
     )
     |> Enum.reduce({[], 0}, fn

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -42,6 +42,11 @@ defmodule Bob.Job.DockerChecker do
     |> Map.new(fn {repo, regexes} -> {repo, tags(repo, regexes)} end)
   end
 
+  @doc "The base-image os_versions the build matrix currently targets."
+  def current_os_versions(), do: os_versions(builds())
+
+  defp os_versions(builds), do: builds |> Map.values() |> List.flatten()
+
   defp tags(repo, regexes) do
     tags =
       ("library/" <> repo)
@@ -429,10 +434,8 @@ defmodule Bob.Job.DockerChecker do
   # only ones expected_elixir_tags/0 can use. Rows returned here always carry
   # search metadata, so the tag is guaranteed to match @erlang_tag_regex.
   defp current_erlang_tags(builds) do
-    os_versions = builds |> Map.values() |> List.flatten()
-
     @erlang_arch_repos
-    |> Bob.Artifacts.erlang_tags_for_os_versions(os_versions)
+    |> Bob.Artifacts.erlang_tags_for_os_versions(os_versions(builds))
     |> Enum.map(fn {"hexpm/erlang-" <> arch, tag} ->
       [erlang, os, os_version] = Regex.run(@erlang_tag_regex, tag, capture: :all_but_first)
       {erlang, os, os_version, arch}

--- a/lib/bob_web/live/request_live.ex
+++ b/lib/bob_web/live/request_live.ex
@@ -278,8 +278,8 @@ defmodule BobWeb.RequestLive do
         <p class="req-intro">
           Requesting an image also reserves it from cleanup, permanently — and if the image
           already exists it is reserved without rebuilding. The multi-arch images you pull are
-          never removed; only the per-architecture Elixir build images they are assembled from
-          are cleaned up, after 30 days.
+          never removed; only the per-architecture build images they are assembled from are
+          cleaned up, after 30 days.
         </p>
 
         <form phx-change="validate" phx-submit="request" class="filter-bar filter-bar--wrap">

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -934,10 +934,12 @@ defmodule Bob.ArtifactsTest do
 
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
 
-      assert Artifacts.count_stale_per_arch_tags(cutoff, []) ==
+      current = ["jammy-20250101"]
+
+      assert Artifacts.count_stale_per_arch_tags(cutoff, current) ==
                %{"hexpm/elixir-amd64" => 1, "hexpm/erlang-amd64" => 1}
 
-      assert Artifacts.stale_per_arch_tags(cutoff, 100, []) |> Enum.sort() ==
+      assert Artifacts.stale_per_arch_tags(cutoff, 100, current) |> Enum.sort() ==
                [
                  {"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"},
                  {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"}
@@ -967,6 +969,58 @@ defmodule Bob.ArtifactsTest do
 
       assert Artifacts.deletable_docker_tags(chunk, cutoff, ["noble-20250101"]) ==
                [{"hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101"}]
+    end
+
+    test "no readable build matrix protects every erlang tag" do
+      old = days_ago(40)
+
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"],
+        old
+      )
+
+      # An empty list means the matrix could not be read, not that nothing is
+      # current, so the erlang tags are held back and only elixir is a candidate.
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), []) ==
+               %{"hexpm/elixir-amd64" => 1}
+
+      chunk = [
+        {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"},
+        {"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"}
+      ]
+
+      assert Artifacts.deletable_docker_tags(chunk, days_ago(30), []) ==
+               [{"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"}]
+    end
+
+    test "an elixir build request reserves the erlang image it builds FROM" do
+      old = days_ago(40)
+
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
+
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"],
+        old
+      )
+
+      BuildRequests.create(%{
+        username: "eric",
+        kind: "elixir",
+        elixir: "1.18.0",
+        erlang: "27.0",
+        os: "ubuntu",
+        os_version: "noble-20250101",
+        builds_count: 0
+      })
+
+      # jammy is current, so the noble base is not held by the os_version rule.
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), ["jammy-20250101"]) == %{}
     end
 
     test "a current os_version does not protect an elixir tag" do

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -932,14 +932,53 @@ defmodule Bob.ArtifactsTest do
         old
       )
 
-      # The erlang per-arch repos are not under cleanup — expected_elixir_tags/0
-      # is derived from them, so pruning them silently stops Elixir builds.
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
 
-      assert Artifacts.count_stale_per_arch_tags(cutoff) == %{"hexpm/elixir-amd64" => 1}
+      assert Artifacts.count_stale_per_arch_tags(cutoff, repos(), []) ==
+               %{"hexpm/elixir-amd64" => 1, "hexpm/erlang-amd64" => 1}
 
-      assert Artifacts.stale_per_arch_tags(cutoff, 100) ==
-               [{"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"}]
+      assert Artifacts.stale_per_arch_tags(cutoff, 100, repos(), []) |> Enum.sort() ==
+               [
+                 {"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"},
+                 {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"}
+               ]
+    end
+
+    test "an erlang tag on an os_version the build matrix targets is never a candidate" do
+      old = days_ago(40)
+      cutoff = days_ago(30)
+
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101", ["amd64"], old)
+
+      # expected_elixir_tags/0 ranks these by version, not date, so the newest
+      # tag of an old OTP line stays in use however old it gets.
+      assert Artifacts.count_stale_per_arch_tags(cutoff, repos(), ["noble-20250101"]) ==
+               %{"hexpm/erlang-amd64" => 1}
+
+      assert Artifacts.stale_per_arch_tags(cutoff, 100, repos(), ["noble-20250101"]) ==
+               [{"hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101"}]
+
+      # And the per-chunk re-check applies the same rule.
+      chunk = [
+        {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"},
+        {"hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101"}
+      ]
+
+      assert Artifacts.deletable_docker_tags(chunk, cutoff, ["noble-20250101"]) ==
+               [{"hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101"}]
+    end
+
+    test "a current os_version does not protect an elixir tag" do
+      Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"],
+        days_ago(40)
+      )
+
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), ["noble-20250101"]) ==
+               %{"hexpm/elixir-amd64" => 1}
     end
 
     test "a non-expired build request reserves its per-arch tags" do
@@ -969,7 +1008,7 @@ defmodule Bob.ArtifactsTest do
         builds_count: 0
       })
 
-      assert Artifacts.count_stale_per_arch_tags(days_ago(30)) == %{}
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), []) == %{}
     end
 
     test "an expired build request does not reserve its tags" do
@@ -992,7 +1031,8 @@ defmodule Bob.ArtifactsTest do
 
       BuildRequests.expire(request)
 
-      assert Artifacts.count_stale_per_arch_tags(days_ago(30)) == %{"hexpm/elixir-amd64" => 1}
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), []) ==
+               %{"hexpm/elixir-amd64" => 1}
     end
 
     test "delete_docker_tags removes the given rows" do
@@ -1047,6 +1087,8 @@ defmodule Bob.ArtifactsTest do
   end
 
   defp days_ago(days), do: DateTime.add(DateTime.utc_now(), -days, :day)
+
+  defp repos(), do: Artifacts.docker_cleanup_per_arch_repos()
 
   defp replace(repo, tag_archs) do
     token = Ecto.UUID.generate()

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -934,10 +934,10 @@ defmodule Bob.ArtifactsTest do
 
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"], old)
 
-      assert Artifacts.count_stale_per_arch_tags(cutoff, repos(), []) ==
+      assert Artifacts.count_stale_per_arch_tags(cutoff, []) ==
                %{"hexpm/elixir-amd64" => 1, "hexpm/erlang-amd64" => 1}
 
-      assert Artifacts.stale_per_arch_tags(cutoff, 100, repos(), []) |> Enum.sort() ==
+      assert Artifacts.stale_per_arch_tags(cutoff, 100, []) |> Enum.sort() ==
                [
                  {"hexpm/elixir-amd64", "1.18.0-erlang-27.0-ubuntu-noble-20250101"},
                  {"hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101"}
@@ -953,10 +953,10 @@ defmodule Bob.ArtifactsTest do
 
       # expected_elixir_tags/0 ranks these by version, not date, so the newest
       # tag of an old OTP line stays in use however old it gets.
-      assert Artifacts.count_stale_per_arch_tags(cutoff, repos(), ["noble-20250101"]) ==
+      assert Artifacts.count_stale_per_arch_tags(cutoff, ["noble-20250101"]) ==
                %{"hexpm/erlang-amd64" => 1}
 
-      assert Artifacts.stale_per_arch_tags(cutoff, 100, repos(), ["noble-20250101"]) ==
+      assert Artifacts.stale_per_arch_tags(cutoff, 100, ["noble-20250101"]) ==
                [{"hexpm/erlang-amd64", "27.0-ubuntu-jammy-20240101"}]
 
       # And the per-chunk re-check applies the same rule.
@@ -977,7 +977,7 @@ defmodule Bob.ArtifactsTest do
         days_ago(40)
       )
 
-      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), ["noble-20250101"]) ==
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), ["noble-20250101"]) ==
                %{"hexpm/elixir-amd64" => 1}
     end
 
@@ -1008,7 +1008,7 @@ defmodule Bob.ArtifactsTest do
         builds_count: 0
       })
 
-      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), []) == %{}
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), []) == %{}
     end
 
     test "an expired build request does not reserve its tags" do
@@ -1031,7 +1031,7 @@ defmodule Bob.ArtifactsTest do
 
       BuildRequests.expire(request)
 
-      assert Artifacts.count_stale_per_arch_tags(days_ago(30), repos(), []) ==
+      assert Artifacts.count_stale_per_arch_tags(days_ago(30), []) ==
                %{"hexpm/elixir-amd64" => 1}
     end
 
@@ -1087,8 +1087,6 @@ defmodule Bob.ArtifactsTest do
   end
 
   defp days_ago(days), do: DateTime.add(DateTime.utc_now(), -days, :day)
-
-  defp repos(), do: Artifacts.docker_cleanup_per_arch_repos()
 
   defp replace(repo, tag_archs) do
     token = Ecto.UUID.generate()

--- a/test/bob/docker_cleanup_test.exs
+++ b/test/bob/docker_cleanup_test.exs
@@ -216,61 +216,6 @@ defmodule Bob.DockerCleanupTest do
     end
   end
 
-  describe "run/1 scoped to some repos" do
-    setup do
-      for repo <- ~w(hexpm/elixir-amd64 hexpm/elixir-arm64) do
-        Artifacts.add_docker_tag(
-          repo,
-          "1.18.0-erlang-27.0-ubuntu-noble-20250101",
-          ["amd64"],
-          old()
-        )
-      end
-
-      :ok
-    end
-
-    test "deletes only from the named repo" do
-      test = self()
-      deleter = fn repo, _tag -> send(test, {:deleted, repo}) && :ok end
-
-      assert {:live, 1} =
-               DockerCleanup.run(
-                 mode: :live,
-                 deleter: deleter,
-                 repos: ["hexpm/elixir-amd64"]
-               )
-
-      assert_received {:deleted, "hexpm/elixir-amd64"}
-      refute_received {:deleted, "hexpm/elixir-arm64"}
-      assert Artifacts.docker_tags("hexpm/elixir-arm64") != []
-    end
-
-    test "the dry run counts only the named repo" do
-      assert {:dry_run, %{per_arch: counts}} =
-               DockerCleanup.run(mode: :dry_run, repos: ["hexpm/elixir-arm64"])
-
-      assert counts == %{"hexpm/elixir-arm64" => 1}
-    end
-
-    # A repo outside the list would be the images users pull.
-    test "a repo outside the per-arch list is ignored, not deleted from" do
-      deleter = fn _repo, _tag -> :ok end
-
-      Artifacts.add_docker_tag(
-        "hexpm/elixir",
-        "1.17.0-erlang-27.0-ubuntu-noble-20250101",
-        ["amd64", "arm64"],
-        ancient()
-      )
-
-      assert {:live, 0} =
-               DockerCleanup.run(mode: :live, deleter: deleter, repos: ["hexpm/elixir"])
-
-      assert Artifacts.docker_tags("hexpm/elixir") != []
-    end
-  end
-
   describe "run/1 clears the whole backlog" do
     test "keeps taking batches until nothing is left" do
       deleter = fn _repo, _tag -> :ok end

--- a/test/bob/docker_cleanup_test.exs
+++ b/test/bob/docker_cleanup_test.exs
@@ -403,20 +403,4 @@ defmodule Bob.DockerCleanupTest do
     end)
     |> Enum.take_while(&(&1 != :__empty__))
   end
-
-  defp drain_messages(take) do
-    Stream.repeatedly(fn ->
-      receive do
-        m -> m
-      after
-        0 -> :done
-      end
-    end)
-    |> Enum.take_while(&(&1 != :done))
-    |> Enum.map(fn
-      {:remaining, n} -> n
-      other -> other
-    end)
-    |> tap(fn _ -> take end)
-  end
 end

--- a/test/bob_web/live/docker_tags_live_test.exs
+++ b/test/bob_web/live/docker_tags_live_test.exs
@@ -67,7 +67,9 @@ defmodule BobWeb.DockerTagsLiveTest do
 
     assert reserved?(html, "1.18.0-erlang-27.0-ubuntu-noble-20250101")
     refute reserved?(html, "1.18.1-erlang-27.0-ubuntu-noble-20250101")
-    refute reserved?(html, "27.0-ubuntu-noble-20250101")
+
+    # The elixir image is built FROM this one, so the request holds it too.
+    assert reserved?(html, "27.0-ubuntu-noble-20250101")
   end
 
   test "applies filters from URL params on load", %{conn: conn} do


### PR DESCRIPTION
The erlang per-arch repos were left out of the cleanup because `DockerChecker.expected_elixir_tags/0` reads those rows to decide which Elixir images to build. It ranks them by version rather than by date, so the newest tag of an old OTP line stays in use however old it gets and a plain age cutoff would delete it.

Keeping the erlang tags whose `os_version` the build matrix currently targets is enough to protect that, and costs 420 of the 71,061 stale erlang tags. Both sides read the same `builds()`: a build request whose `os_version` is not current is expired rather than built, so a request can never need a base image the cleanup has taken. The os_versions are re-read per batch so a base image released mid-run pulls the tags built against it back under protection, and the per-chunk re-check applies the same rule.

Every Elixir image is `FROM hexpm/erlang-${ARCH}:${ERLANG}-${os}-${OS_VERSION}`, and an elixir build request does not reserve that base tag. It does not need to, given the above, and `request_jobs/1` already enqueues the erlang build instead of the elixir one when the base is missing.

`:repos` goes with it. It existed to point one node at each per-arch repo on the theory that Docker Hub metered per source IP; it meters per account, so a second node draws down the same budget and the two together get no more through than one. Nothing passes the option, so the repo list stops being a parameter and the filter that kept a caller from aiming the deleter at a manifest repo goes with it.

The dry run no longer claims a scheduled run stops at one batch. It has cleared the whole backlog since #279.