### PR TITLE
Tell a missing arch apart from one that did not read

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -38,11 +38,11 @@ defmodule Bob.Artifacts do
       INSERT INTO docker_tags (repo, tag, archs, search, built_at, inserted_at, updated_at)
       VALUES ($1, $2, $3, $4, $5, $6, $6)
       ON CONFLICT (repo, tag)
+      -- archs is taken from the caller, so a manifest that loses one is visible
+      -- here. manifest_mismatches/3 reads this row to decide whether the
+      -- manifest still spans everything that was built.
       DO UPDATE SET
-        archs = (
-          SELECT array_agg(DISTINCT a ORDER BY a)
-          FROM unnest(docker_tags.archs || EXCLUDED.archs) AS a
-        ),
+        archs = EXCLUDED.archs,
         search = EXCLUDED.search,
         built_at = EXCLUDED.built_at,
         updated_at = EXCLUDED.updated_at

--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -41,6 +41,14 @@ defmodule Bob.DockerHub do
     end
   end
 
+  @doc """
+  Fetches a tag as `{:ok, {name, archs, built_at}}`.
+
+  `:not_found` is Docker Hub saying the tag is gone. `:unreadable` is a response
+  that carried no usable image data, which says nothing about the tag either
+  way — callers deciding what an image should contain have to tell the two
+  apart.
+  """
   def fetch_tag(repo, tag) do
     url = @dockerhub_url <> "v2/repositories/#{repo}/tags/#{tag}"
     headers = headers()
@@ -53,10 +61,13 @@ defmodule Bob.DockerHub do
 
     case result do
       {:ok, 200, _headers, body} ->
-        parse(JSON.decode!(body))
+        case parse(JSON.decode!(body)) do
+          nil -> :unreadable
+          parsed -> {:ok, parsed}
+        end
 
       {:ok, 404, _headers, _body} ->
-        nil
+        :not_found
     end
   end
 

--- a/lib/bob/job/docker_manifest.ex
+++ b/lib/bob/job/docker_manifest.ex
@@ -5,18 +5,26 @@ defmodule Bob.Job.DockerManifest do
     directory = Bob.Directory.new()
     Logger.info("Using directory #{directory}")
     tag = key_to_tag(kind, key)
-    archs = get_archs(kind, tag)
 
-    if archs == [] do
-      :ok
-    else
-      Bob.Script.run(
-        {:script, "docker/manifest.sh"},
-        [kind, tag] ++ archs,
-        directory
-      )
+    case get_archs(kind, tag) do
+      {:ok, []} ->
+        :ok
 
-      Bob.RemoteQueue.docker_add("hexpm/#{kind}", tag, archs)
+      {:ok, archs} ->
+        Bob.Script.run(
+          {:script, "docker/manifest.sh"},
+          [kind, tag] ++ archs,
+          directory
+        )
+
+        Bob.RemoteQueue.docker_add("hexpm/#{kind}", tag, archs)
+
+      {:unreadable, arch} ->
+        Logger.warning(
+          "MANIFEST hexpm/#{kind}:#{tag} left alone, hexpm/#{kind}-#{arch}:#{tag} did not read"
+        )
+
+        :ok
     end
   end
 
@@ -32,12 +40,27 @@ defmodule Bob.Job.DockerManifest do
     "#{elixir}-erlang-#{erlang}-#{os}-#{os_version}"
   end
 
-  def get_archs(kind, tag) do
+  @doc """
+  The archs to publish the manifest from.
+
+  A tag Docker Hub reports as gone is absent, and the manifest is published from
+  whatever else is there — that is how a tag gets a manifest while its second
+  arch is still building. A response that carries no usable image data says
+  nothing about the tag, and publishing on it would rewrite a multi-arch
+  manifest as whatever happened to be legible.
+  """
+  def get_archs(kind, tag, fetch \\ &Bob.DockerHub.fetch_tag/2) do
     ["amd64", "arm64"]
-    |> Enum.map(&{&1, Bob.DockerHub.fetch_tag("hexpm/#{kind}-#{&1}", tag)})
-    |> Enum.flat_map(fn
-      {_arch, nil} -> []
-      {arch, _} -> [arch]
+    |> Enum.reduce_while([], fn arch, acc ->
+      case fetch.("hexpm/#{kind}-#{arch}", tag) do
+        {:ok, _tag} -> {:cont, [arch | acc]}
+        :not_found -> {:cont, acc}
+        :unreadable -> {:halt, {:unreadable, arch}}
+      end
     end)
+    |> case do
+      {:unreadable, arch} -> {:unreadable, arch}
+      archs -> {:ok, Enum.reverse(archs)}
+    end
   end
 end

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -217,12 +217,12 @@ defmodule Bob.ArtifactsTest do
       assert [%DockerTag{built_at: @docker_built_at}] = Repo.all(DockerTag)
     end
 
-    test "unions archs on conflicting (repo, tag)" do
+    test "takes the archs from the report, so a manifest that loses one shows it" do
+      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64", "arm64"])
       Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64"])
-      Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["arm64"])
 
       assert Artifacts.docker_tags("hexpm/erlang") ==
-               [{"27.0-ubuntu-noble-20250101", ["amd64", "arm64"]}]
+               [{"27.0-ubuntu-noble-20250101", ["amd64"]}]
     end
 
     test "is idempotent for a repeated single-arch report" do

--- a/test/bob/job/docker_manifest_test.exs
+++ b/test/bob/job/docker_manifest_test.exs
@@ -1,0 +1,47 @@
+defmodule Bob.Job.DockerManifestTest do
+  use ExUnit.Case, async: true
+
+  alias Bob.Job.DockerManifest
+
+  defp fetcher(results) do
+    fn repo, _tag ->
+      arch = repo |> String.split("-") |> List.last()
+      Map.fetch!(results, arch)
+    end
+  end
+
+  defp built(arch), do: {:ok, {"a-tag", [arch], DateTime.utc_now()}}
+
+  describe "get_archs/3" do
+    test "publishes from every arch Docker Hub has" do
+      fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => built("arm64")})
+
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, ["amd64", "arm64"]}
+    end
+
+    test "publishes from what is there while the other arch is still building" do
+      fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => :not_found})
+
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, ["amd64"]}
+    end
+
+    test "publishes nothing when neither arch is there" do
+      fetch = fetcher(%{"amd64" => :not_found, "arm64" => :not_found})
+
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, []}
+    end
+
+    test "refuses to publish when an arch did not read" do
+      # Answering on this would rewrite a two-arch manifest as amd64 only.
+      fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => :unreadable})
+
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:unreadable, "arm64"}
+    end
+
+    test "refuses to publish when the first arch did not read" do
+      fetch = fetcher(%{"amd64" => :unreadable, "arm64" => built("arm64")})
+
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:unreadable, "amd64"}
+    end
+  end
+end


### PR DESCRIPTION
`hexpm/elixir:1.16-erlang-26.2.5.15-alpine-3.21.5` is a single-arch amd64 manifest in the registry right now, not a multi-arch index, so arm64 pulls of it get an amd64 image. Both per-arch images have been present since 2025-10-09; the manifest was rewritten at 2026-07-30 02:24 without anything being built.

`fetch_tag/2` returned `nil` both when Docker Hub said the tag was gone and when it answered 200 with a body carrying no usable image data, and `get_archs/2` dropped the arch either way. One unreadable response was enough for `manifest.sh` to run `imagetools create` with a single source, which replaces the index with a copy of that one manifest. `fetch_tag/2` now answers `:not_found` or `:unreadable`, and the manifest is published only once every arch has answered. A 404 still counts as absent, which is how a tag gets a manifest while its second arch is still building.

`add_docker_tag/4` merged the reported archs into the existing row, so the re-publish recorded the loss as a no-op and the row still claimed both archs. `manifest_mismatches/3` reads that row, so nothing looked wrong afterwards and the tag stayed broken until the next reconcile happened to replace the row. The row now takes the archs it is given, which is also what `swap_docker_tags/2` already does.

The bad reads come from Docker Hub's tag API. It currently reports `1.20.2-erlang-29.0.4-debian-trixie-20260713-slim` as arm64-only while the registry has both platforms — that is what reconcile writes at 01:00, and what the 02:15 check acts on by re-publishing. With this change that re-publish is still churn, but it can no longer degrade the tag.

Repairing the already-broken tag is not part of this. Both of its per-arch tags read cleanly, so a `DockerManifest` run rebuilds the index correctly.