### PR TITLE
Build a manifest only when it adds an arch or a push

### DIFF
--- a/lib/bob/job/docker_manifest.ex
+++ b/lib/bob/job/docker_manifest.ex
@@ -1,23 +1,31 @@
 defmodule Bob.Job.DockerManifest do
   require Logger
 
+  @archs ["amd64", "arm64"]
+
   def run(kind, key) do
-    directory = Bob.Directory.new()
-    Logger.info("Using directory #{directory}")
     tag = key_to_tag(kind, key)
 
     case get_archs(kind, tag) do
       {:ok, []} ->
         :ok
 
-      {:ok, archs} ->
-        Bob.Script.run(
-          {:script, "docker/manifest.sh"},
-          [kind, tag] ++ archs,
-          directory
-        )
+      {:ok, sources} ->
+        if publish?(kind, tag, sources) do
+          directory = Bob.Directory.new()
+          Logger.info("Using directory #{directory}")
+          archs = Enum.map(sources, fn {arch, _built_at} -> arch end)
 
-        Bob.RemoteQueue.docker_add("hexpm/#{kind}", tag, archs)
+          Bob.Script.run(
+            {:script, "docker/manifest.sh"},
+            [kind, tag] ++ archs,
+            directory
+          )
+
+          Bob.RemoteQueue.docker_add("hexpm/#{kind}", tag, archs)
+        else
+          :ok
+        end
 
       {:unreadable, arch} ->
         Logger.warning(
@@ -41,26 +49,57 @@ defmodule Bob.Job.DockerManifest do
   end
 
   @doc """
-  The archs to publish the manifest from.
+  Whether a manifest should be built from `sources`, each an `{arch, built_at}`.
 
-  A tag Docker Hub reports as gone is absent, and the manifest is published from
-  whatever else is there — that is how a tag gets a manifest while its second
-  arch is still building. A response that carries no usable image data says
-  nothing about the tag, and publishing on it would rewrite a multi-arch
-  manifest as whatever happened to be legible.
+  A manifest spans the arches it was built from, and those per-arch tags are
+  deleted once they are 30 days old, so building from what survives would drop
+  the rest. Anything that would lose an arch is left alone.
+
+  Beyond that it is built when it would gain an arch, or when a source has been
+  pushed since it was last built — the same tag can be re-pushed under a new
+  digest, and the manifest has to follow. A manifest already spanning these
+  arches and newer than all of them is left as it is rather than rewritten as
+  itself.
+  """
+  def publish?(kind, tag, sources, fetch \\ &Bob.DockerHub.fetch_tag/2) do
+    case fetch.("hexpm/#{kind}", tag) do
+      :not_found ->
+        true
+
+      :unreadable ->
+        false
+
+      {:ok, {_tag, published, built_at}} ->
+        archs = MapSet.new(sources, fn {arch, _at} -> arch end)
+        published = MapSet.new(published)
+
+        cond do
+          not MapSet.subset?(published, archs) -> false
+          not MapSet.equal?(published, archs) -> true
+          true -> Enum.any?(sources, fn {_arch, at} -> DateTime.compare(at, built_at) == :gt end)
+        end
+    end
+  end
+
+  @doc """
+  The `{arch, built_at}` sources to build the manifest from.
+
+  A tag Docker Hub reports as gone is absent. A response that carries no usable
+  image data says nothing about the tag, and building on it would rewrite a
+  multi-arch manifest as whatever happened to be legible.
   """
   def get_archs(kind, tag, fetch \\ &Bob.DockerHub.fetch_tag/2) do
-    ["amd64", "arm64"]
+    @archs
     |> Enum.reduce_while([], fn arch, acc ->
       case fetch.("hexpm/#{kind}-#{arch}", tag) do
-        {:ok, _tag} -> {:cont, [arch | acc]}
+        {:ok, {_tag, _archs, built_at}} -> {:cont, [{arch, built_at} | acc]}
         :not_found -> {:cont, acc}
         :unreadable -> {:halt, {:unreadable, arch}}
       end
     end)
     |> case do
       {:unreadable, arch} -> {:unreadable, arch}
-      archs -> {:ok, Enum.reverse(archs)}
+      sources -> {:ok, Enum.reverse(sources)}
     end
   end
 end

--- a/test/bob/job/docker_manifest_test.exs
+++ b/test/bob/job/docker_manifest_test.exs
@@ -3,6 +3,10 @@ defmodule Bob.Job.DockerManifestTest do
 
   alias Bob.Job.DockerManifest
 
+  @epoch ~U[2026-01-01 00:00:00Z]
+
+  defp at(seconds), do: DateTime.add(@epoch, seconds, :second)
+
   defp fetcher(results) do
     fn repo, _tag ->
       arch = repo |> String.split("-") |> List.last()
@@ -10,38 +14,91 @@ defmodule Bob.Job.DockerManifestTest do
     end
   end
 
-  defp built(arch), do: {:ok, {"a-tag", [arch], DateTime.utc_now()}}
+  defp built(arch, seconds \\ 0), do: {:ok, {"a-tag", [arch], at(seconds)}}
+
+  defp manifest(archs, seconds),
+    do: fn "hexpm/elixir", _tag -> {:ok, {"a-tag", archs, at(seconds)}} end
 
   describe "get_archs/3" do
-    test "publishes from every arch Docker Hub has" do
-      fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => built("arm64")})
+    test "takes every arch Docker Hub has, with when it was pushed" do
+      fetch = fetcher(%{"amd64" => built("amd64", 10), "arm64" => built("arm64", 20)})
 
-      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, ["amd64", "arm64"]}
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) ==
+               {:ok, [{"amd64", at(10)}, {"arm64", at(20)}]}
     end
 
-    test "publishes from what is there while the other arch is still building" do
+    test "takes what is there while the other arch is still building" do
       fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => :not_found})
 
-      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, ["amd64"]}
+      assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, [{"amd64", at(0)}]}
     end
 
-    test "publishes nothing when neither arch is there" do
+    test "takes nothing when neither arch is there" do
       fetch = fetcher(%{"amd64" => :not_found, "arm64" => :not_found})
 
       assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:ok, []}
     end
 
-    test "refuses to publish when an arch did not read" do
+    test "refuses when an arch did not read" do
       # Answering on this would rewrite a two-arch manifest as amd64 only.
       fetch = fetcher(%{"amd64" => built("amd64"), "arm64" => :unreadable})
 
       assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:unreadable, "arm64"}
     end
 
-    test "refuses to publish when the first arch did not read" do
+    test "refuses when the first arch did not read" do
       fetch = fetcher(%{"amd64" => :unreadable, "arm64" => built("arm64")})
 
       assert DockerManifest.get_archs("elixir", "a-tag", fetch) == {:unreadable, "amd64"}
+    end
+  end
+
+  describe "publish?/4" do
+    test "builds when there is no manifest yet" do
+      fetch = fn "hexpm/elixir", _tag -> :not_found end
+
+      assert DockerManifest.publish?("elixir", "a-tag", [{"amd64", at(0)}], fetch)
+    end
+
+    test "builds when the set grows" do
+      sources = [{"amd64", at(0)}, {"arm64", at(10)}]
+
+      assert DockerManifest.publish?("elixir", "a-tag", sources, manifest(["amd64"], 5))
+    end
+
+    test "builds when a source was pushed after the manifest was built" do
+      # The same tag can be re-pushed under a new digest, and the manifest has
+      # to follow it.
+      sources = [{"amd64", at(100)}, {"arm64", at(10)}]
+
+      assert DockerManifest.publish?("elixir", "a-tag", sources, manifest(["amd64", "arm64"], 50))
+    end
+
+    test "leaves a manifest newer than all of its sources alone" do
+      sources = [{"amd64", at(10)}, {"arm64", at(20)}]
+
+      refute DockerManifest.publish?("elixir", "a-tag", sources, manifest(["amd64", "arm64"], 50))
+    end
+
+    test "leaves a manifest alone when an arch it spans is gone" do
+      # The per-arch tag the other half was built from is cleaned up after 30
+      # days, so this would republish a two-arch tag as one.
+      sources = [{"amd64", at(100)}]
+
+      refute DockerManifest.publish?("elixir", "a-tag", sources, manifest(["amd64", "arm64"], 50))
+    end
+
+    test "leaves a manifest alone when the sets only overlap" do
+      sources = [{"arm64", at(100)}]
+
+      refute DockerManifest.publish?("elixir", "a-tag", sources, manifest(["amd64"], 50))
+    end
+
+    test "leaves a manifest alone when it did not read" do
+      fetch = fn "hexpm/elixir", _tag -> :unreadable end
+      sources = [{"amd64", at(0)}, {"arm64", at(0)}]
+
+      refute DockerManifest.publish?("elixir", "a-tag", sources, fetch)
     end
   end
 end


### PR DESCRIPTION
The per-arch tags a manifest was built from are deleted once they are 30 days old, and the manifest repos are never pruned, so from that point on any rebuild has fewer sources than the manifest already spans.

Normally nothing triggers a rebuild: `manifest_mismatches/3` compares the manifest row against the per-arch rows, and `m.archs @> p.archs` keeps holding as the per-arch rows shrink under it. What breaks that is a reconcile recording a short arch set, and Docker Hub's tag API produces those — it currently reports `1.20.2-erlang-29.0.4-debian-trixie-20260713-slim` as arm64-only while the registry has both platforms. The rebuild that follows drops whichever arch cleanup had already taken, and the manifest users pull becomes single-arch.

#282 taught `get_archs/3` to tell an unreadable response from a 404, but a per-arch tag that cleanup deleted is a genuine 404, so that guard does not cover this case. Anything that would lose an arch is now left alone, including sets that only overlap, so a rebuild can never swap one arch for another.

Membership alone is not enough to decide the rest, because the same tag can be re-pushed under a new digest. `BuildDockerElixir.run/5` and `BuildDockerErlang` push before reporting the tag, so a job killed in between leaves Docker Hub ahead of the database and the retry pushes a fresh digest under the same name. A rule that skipped whenever the arch set was unchanged would leave the manifest pointing at the old digests. So a manifest is also built when a source is newer than it, and left alone only when it already spans these arches *and* postdates all of them.

That last part also stops the pointless rebuild: those runs published the same manifest again and moved its `last_updated`, which is what the tag list renders as the build date, so a tag untouched for months read as freshly built.

A tag with no manifest yet still takes whatever is there, which is how it gets one while its second arch is still building.

Costs one extra Docker Hub read per run, on a job that only fires on a mismatch or after a build.

Exposure grows with the backlog drain: the condition is "at least one per-arch tag already deleted", which becomes true for essentially every tag as it completes. There were 0 manifest mismatches and no republishes when this was written, so nothing is degrading right now.

`hexpm/elixir:1.16-erlang-26.2.5.15-alpine-3.21.5`, degraded this way on 2026-07-30, still has both per-arch tags, so it grows the set from `[amd64]` to `[amd64, arm64]` and republishes correctly.