### PR TITLE
Raise work_mem for the tag swap transaction

### DIFF
--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -99,6 +99,11 @@ defmodule Bob.Artifacts do
 
     Repo.transaction(
       fn ->
+        # Scoped to this transaction. The insert sorts the whole staged set and
+        # the delete hashes it, up to ~1M rows for hexpm/elixir, which spills at
+        # the 4MB default: a 229MB sort file and 63 hash batches per swap.
+        Repo.query!("SET LOCAL work_mem = '256MB'")
+
         Repo.query!(
           """
           INSERT INTO docker_tags (repo, tag, archs, search, built_at, inserted_at, updated_at)

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -277,6 +277,27 @@ defmodule Bob.ArtifactsTest do
              ] = Repo.all(DockerTag)
     end
 
+    test "raises work_mem for the swap transaction" do
+      test = self()
+      ref = make_ref()
+
+      :telemetry.attach(
+        ref,
+        Repo.config()[:telemetry_prefix] ++ [:query],
+        fn _event, _measurements, %{query: query}, _config ->
+          # Handlers are global, so only this process's queries count.
+          if self() == test and query =~ "work_mem", do: send(test, {ref, query})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(ref) end)
+
+      replace("hexpm/erlang-amd64", [docker_tag("27.0-ubuntu-noble-20250101", ["amd64"])])
+
+      assert_received {^ref, "SET LOCAL work_mem = '256MB'"}
+    end
+
     test "swaps the staged Docker Hub timestamp into built_at" do
       replace("hexpm/erlang-amd64", [
         docker_tag("27.0-ubuntu-noble-20250101", ["amd64"], @docker_built_at)


### PR DESCRIPTION
Both statements in `swap_docker_tags/2` process the whole staged set, about 1M rows for `hexpm/elixir`, and both spill at the server's 4MB `work_mem`.

From one night's Cloud SQL temp file logs, a single swap wrote 391MB. The `INSERT ... DISTINCT ON` sorts into one 229MB external merge file, and the `DELETE ... NOT EXISTS` anti-join runs at 64 batches, writing 63 files of 2.58MB. That is most of the 395MB bob wrote in 24 hours.

256MB holds the hash side in one batch and cuts the sort to a single merge pass. `Reconcile` walks its repos with `Enum.each`, so one of these transactions is open at a time on one connection.

Same shape as the `SET LOCAL work_mem` the hexpm stats job already uses for its matview refresh. hexpm/hexpm-ops#240 raises the instance-wide default to 16MB, which is sized for ordinary web queries and nowhere near enough for this one.

The test asserts the statement is issued during a swap, filtered to the test process because telemetry handlers are global. I checked it discriminates by removing the `SET LOCAL` and confirming it fails.