### PR TITLE
Reload stale clients instead of rendering new markup with old assets

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -4,6 +4,8 @@ config :bob,
   tmp_dir: "/tmp",
   persist_dir: "/persist"
 
+config :bob, BobWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
+
 config :logger, level: :info
 
 config :sentry,

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,4 +29,8 @@ config :bob, Bob.Repo,
 config :bob, BobWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "tT9wQ2eR5yU8iO1pA4sD7fG0hJ3kL6zX9cV2bN5mQ8wE1rT4yU7iO0pA3sD6fG90",
-  server: false
+  server: false,
+  cache_static_manifest_latest: %{
+    "assets/app.css" => "assets/app-11111111111111111111111111111111.css",
+    "assets/app.js" => "assets/app-22222222222222222222222222222222.js"
+  }

--- a/lib/bob_web/endpoint.ex
+++ b/lib/bob_web/endpoint.ex
@@ -16,11 +16,14 @@ defmodule BobWeb.Endpoint do
   plug(Bob.Plug.Forwarded)
   plug(Bob.Plug.Status)
 
+  # only_matching also serves the digested /favicon-<hash>.ico that
+  # ~p"/favicon.ico" resolves to when the static manifest is loaded.
   plug(Plug.Static,
     at: "/",
     from: :bob,
     gzip: Mix.env() != :dev,
-    only: BobWeb.static_paths()
+    only: BobWeb.static_paths(),
+    only_matching: ~w(favicon)
   )
 
   if Mix.env() == :dev do

--- a/lib/bob_web/router.ex
+++ b/lib/bob_web/router.ex
@@ -43,7 +43,8 @@ defmodule BobWeb.Router do
     get("/oauth/callback", OAuthController, :callback)
     post("/oauth/logout", OAuthController, :logout)
 
-    live_session :default, on_mount: [{BobWeb.UserAuth, :mount_current_user}] do
+    live_session :default,
+      on_mount: [{BobWeb.UserAuth, :mount_current_user}, BobWeb.StaticReload] do
       live("/", JobsLive)
       live("/artifacts", ArtifactsLive)
       live("/docker", DockerTagsLive)
@@ -53,7 +54,8 @@ defmodule BobWeb.Router do
   scope "/", BobWeb do
     pipe_through([:browser, :require_authenticated_user])
 
-    live_session :authenticated, on_mount: [{BobWeb.UserAuth, :ensure_authenticated}] do
+    live_session :authenticated,
+      on_mount: [{BobWeb.UserAuth, :ensure_authenticated}, BobWeb.StaticReload] do
       live("/request", RequestLive)
     end
   end

--- a/lib/bob_web/static_reload.ex
+++ b/lib/bob_web/static_reload.ex
@@ -1,0 +1,21 @@
+defmodule BobWeb.StaticReload do
+  import Phoenix.LiveView
+
+  # A client that reconnects across a deploy still runs the CSS and JS it
+  # loaded before the deploy, so markup from the new server renders unstyled
+  # and new hooks are missing. A full redirect makes the browser reload the
+  # page and fetch the current assets.
+  def on_mount(:default, _params, _session, socket) do
+    if connected?(socket) and static_changed?(socket) do
+      {:cont,
+       attach_hook(socket, :static_reload, :handle_params, fn _params, uri, socket ->
+         {:halt, redirect(socket, to: path_with_query(URI.parse(uri)))}
+       end)}
+    else
+      {:cont, socket}
+    end
+  end
+
+  defp path_with_query(%URI{path: path, query: nil}), do: path
+  defp path_with_query(%URI{path: path, query: query}), do: path <> "?" <> query
+end

--- a/test/bob_web/static_reload_test.exs
+++ b/test/bob_web/static_reload_test.exs
@@ -1,0 +1,34 @@
+defmodule BobWeb.StaticReloadTest do
+  use BobWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  # The digests here match cache_static_manifest_latest in config/test.exs.
+  test "redirects for a full page load when the client's assets are stale", %{conn: conn} do
+    conn =
+      put_connect_params(conn, %{
+        "_track_static" => [
+          "http://localhost:4002/assets/app-00000000000000000000000000000000.css",
+          "http://localhost:4002/assets/app-00000000000000000000000000000000.js"
+        ]
+      })
+
+    assert {:error, {:redirect, %{to: "/docker?tag=1.18"}}} = live(conn, ~p"/docker?tag=1.18")
+  end
+
+  test "mounts when the client's assets are current", %{conn: conn} do
+    conn =
+      put_connect_params(conn, %{
+        "_track_static" => [
+          "http://localhost:4002/assets/app-11111111111111111111111111111111.css",
+          "http://localhost:4002/assets/app-22222222222222222222222222222222.js"
+        ]
+      })
+
+    assert {:ok, _view, _html} = live(conn, ~p"/docker")
+  end
+
+  test "mounts when the client does not track statics", %{conn: conn} do
+    assert {:ok, _view, _html} = live(conn, ~p"/docker")
+  end
+end


### PR DESCRIPTION
A LiveView client that reconnects across a deploy remounts against the new server code while still running the CSS and JS it fetched at page load, so new markup renders unstyled and its hooks are missing. The Docker tags page showed this after #286: overlapping columns and bare copy-feedback icons. One such deploy is enough to break a long-lived tab on every later reconnect, since each remount renders current markup against the tab's frozen stylesheet.

`cache_static_manifest` is now set in prod. The Dockerfile runs `mix assets.deploy`, but without the manifest the endpoint served undigested `/assets/app.css` URLs, which give `static_changed?/1` nothing to compare. With the manifest every deploy gets new digested asset URLs, served immutable with a year of caching in place of the etag revalidation the undigested paths rely on.

The new `StaticReload` on_mount hook, added to both live sessions, checks the client's `phx-track-static` hrefs on connect and issues a full redirect to the current URL when they're stale, so the browser reloads the page and fetches the current assets. The redirect is attached as a `handle_params` hook because that's where the current URI is available, and halting there also skips the data load that the reload would discard.

`only_matching: ~w(favicon)` is needed in the endpoint because `~p"/favicon.ico"` now resolves to its digested filename, which the exact-match `only:` list would reject.

Tabs already open before this ships track undigested hrefs, which `static_changed?/1` treats as always current, so they still need one manual reload after their next breakage; tabs loaded after this ships carry digested hrefs and reload automatically from then on.