### PR TITLE
Fix compilation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run tests
         run: |
-          mix test
+          mix test --warnings-as-errors
 
   docker:
     name: Docker

--- a/lib/bob/job/clean.ex
+++ b/lib/bob/job/clean.ex
@@ -1,6 +1,4 @@
 defmodule Bob.Job.Clean do
-  require Logger
-
   def run() do
     directory = Bob.Directory.new()
     Bob.Script.run({:script, "clean.sh"}, [], directory)

--- a/lib/bob/job/docker_checker.ex
+++ b/lib/bob/job/docker_checker.ex
@@ -108,14 +108,8 @@ defmodule Bob.Job.DockerChecker do
         if build_erlang_ref?(os, ref) do
           Stream.flat_map(os_versions, fn os_version ->
             if build_erlang_ref?(os, os_version, ref) do
-              Stream.flat_map(@archs, fn arch ->
-                if build_erlang_ref?(arch, os, os_version, ref) do
-                  "OTP-" <> erlang = ref
-                  [{erlang, os, os_version, arch}]
-                else
-                  []
-                end
-              end)
+              "OTP-" <> erlang = ref
+              Enum.map(@archs, fn arch -> {erlang, os, os_version, arch} end)
             else
               []
             end
@@ -137,8 +131,7 @@ defmodule Bob.Job.DockerChecker do
   def valid_erlang_build?(erlang, os, os_version) do
     ref = "OTP-" <> erlang
 
-    build_erlang_ref?(os, ref) and build_erlang_ref?(os, os_version, ref) and
-      Enum.all?(@archs, &build_erlang_ref?(&1, os, os_version, ref))
+    build_erlang_ref?(os, ref) and build_erlang_ref?(os, os_version, ref)
   end
 
   defp build_erlang_ref?(_os, "OTP-18.0-rc2"), do: false
@@ -171,8 +164,6 @@ defmodule Bob.Job.DockerChecker do
     do: build_ubuntu_26?(version)
 
   defp build_erlang_ref?(_os, _os_version, _ref), do: true
-
-  defp build_erlang_ref?(_arch, _os, _os_version, _ref), do: true
 
   defp build_alpine?(version) do
     version = parse_otp_ref(version)

--- a/test/bob/remote_queue_test.exs
+++ b/test/bob/remote_queue_test.exs
@@ -4,16 +4,12 @@ defmodule Bob.RemoteQueueTest do
   alias Bob.RemoteQueue
 
   defmodule SharedTestJob do
-    require Logger
-
     def priority(), do: 2
     def weight(), do: 4
     def concurrency(), do: :shared
   end
 
   defmodule UnsharedTestJob do
-    require Logger
-
     def priority(), do: 2
     def weight(), do: 4
     def concurrency(), do: __MODULE__

--- a/test/bob/script_test.exs
+++ b/test/bob/script_test.exs
@@ -15,7 +15,7 @@ defmodule Bob.ScriptTest do
                script_dir,
                "\n",
                "COMPLETED " <> _
-             ] = Enum.to_list(File.stream!(Path.join(directory, "out.txt"), [], :line))
+             ] = Enum.to_list(File.stream!(Path.join(directory, "out.txt")))
 
       assert String.trim(script_dir) == Application.app_dir(:bob, "priv/scripts")
     end


### PR DESCRIPTION
## Summary

CI did not catch these issues because it is pinned to Elixir 1.18.4, whereas compiling on Elixir 1.20+ surfaces new compiler diagnostics and deprecations:

1. Bob.Job.Clean: Unused `require Logger` warning (introduced in 1.20).
   - Removed the unused directive.

2. Bob.RemoteQueueTest: Unused `require Logger` in test dummy job modules.
   - Removed the unused directives. Because test files (*_test.exs) are compiled dynamically during test execution rather than via `mix compile`, catching these required inspecting the `mix test` output.
   - Update CI workflow to run `mix test --warnings-as-errors` to catch similar issues in the future.

3. Bob.Job.DockerChecker: Set-theoretic type checker warning where `build_erlang_ref?(arch, os, os_version, ref)` always evaluated to `true` inside an `if` expression, making the `else` branch dead code.
   - Removed the redundant `build_erlang_ref?/4` catch-all and mapped over `@archs` directly. All currently supported OS/OTP pairs build on all target architectures, so no behavior is changed.

4. Bob.ScriptTest: Deprecated `File.stream!(path, modes, line_or_bytes)` argument order from Elixir < 1.13.
   - Replaced with `File.stream!(path)`, which uses the default `:line` mode and empty options without behavior change.

## Testing

```console
$ MIX_ENV=test mix compile --warnings-as-errors
$ mix compile --warnings-as-errors
$ mix test
(make sure no warnings in the output, compilation of `.exs` files not covered by `mix compile`)
```