### PR TITLE
Align Docker tag test fixtures with multi-arch manifests

### DIFF
--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -741,14 +741,14 @@ defmodule Bob.ArtifactsTest do
       Bob.Artifacts.add_docker_tag(
         "hexpm/erlang",
         "old-ubuntu-noble-20250101",
-        ["amd64"],
+        ["amd64", "arm64"],
         ~U[2025-01-01 00:00:00Z]
       )
 
       Bob.Artifacts.add_docker_tag(
         "hexpm/erlang",
         "new-ubuntu-noble-20250101",
-        ["amd64"],
+        ["amd64", "arm64"],
         ~U[2025-02-01 00:00:00Z]
       )
 
@@ -890,33 +890,39 @@ defmodule Bob.ArtifactsTest do
     end
 
     test "distinct Docker repositories" do
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", [
-        "amd64",
-        "arm64"
-      ])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.0-ubuntu-noble-20250101",
+        ["amd64", "arm64"]
+      )
 
       Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
         "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
-        ["amd64"]
+        ["amd64", "arm64"]
       )
 
       assert Bob.Artifacts.distinct_repos() == ["hexpm/elixir", "hexpm/erlang"]
     end
 
     test "search_docker_tags/1 filters by structured prefixes" do
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", [
-        "amd64",
-        "arm64"
-      ])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.0-ubuntu-noble-20250101",
+        ["amd64", "arm64"]
+      )
 
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.1-ubuntu-noble-20250101", [
-        "amd64"
-      ])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang-amd64",
+        "27.1-ubuntu-noble-20250101",
+        ["amd64"]
+      )
 
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "26.2-debian-bookworm-20250113-slim", [
-        "amd64"
-      ])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "26.2-debian-bookworm-20250113-slim",
+        ["amd64", "arm64"]
+      )
 
       Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
@@ -927,7 +933,7 @@ defmodule Bob.ArtifactsTest do
       Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
         "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
-        ["amd64"]
+        ["amd64", "arm64"]
       )
 
       assert [%{tag: "27.0-ubuntu-noble-20250101"}] =
@@ -990,12 +996,19 @@ defmodule Bob.ArtifactsTest do
     end
 
     test "count_docker_tags/1 counts exact matching tags" do
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", [
-        "amd64",
-        "arm64"
-      ])
+      # 27.0 is a complete dual-arch manifest, while 27.1 is intentionally
+      # single-arch to test arch count filtering with partial manifests.
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.0-ubuntu-noble-20250101",
+        ["amd64", "arm64"]
+      )
 
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.1-ubuntu-noble-20250101", ["arm64"])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.1-ubuntu-noble-20250101",
+        ["arm64"]
+      )
 
       count =
         Bob.Artifacts.count_docker_tags(%{
@@ -1018,7 +1031,11 @@ defmodule Bob.ArtifactsTest do
     end
 
     test "search_docker_tags/1 does not treat % or _ as LIKE wildcards" do
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", ["amd64"])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.0-ubuntu-noble-20250101",
+        ["amd64", "arm64"]
+      )
 
       assert Bob.Artifacts.search_docker_tags(%{tag: "%"}) == []
       assert Bob.Artifacts.search_docker_tags(%{repo: "hexpm/_"}) == []

--- a/test/bob_web/live/docker_tags_live_test.exs
+++ b/test/bob_web/live/docker_tags_live_test.exs
@@ -4,10 +4,11 @@ defmodule BobWeb.DockerTagsLiveTest do
   import Phoenix.LiveViewTest
 
   setup do
-    Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", [
-      "amd64",
-      "arm64"
-    ])
+    Bob.Artifacts.add_docker_tag(
+      "hexpm/erlang",
+      "27.0-ubuntu-noble-20250101",
+      ["amd64", "arm64"]
+    )
 
     Bob.Artifacts.add_docker_tag(
       "hexpm/elixir",
@@ -16,7 +17,7 @@ defmodule BobWeb.DockerTagsLiveTest do
     )
 
     Bob.Artifacts.add_docker_tag(
-      "hexpm/elixir",
+      "hexpm/elixir-arm64",
       "1.18.1-erlang-27.0-ubuntu-noble-20250101",
       ["arm64"]
     )
@@ -24,7 +25,7 @@ defmodule BobWeb.DockerTagsLiveTest do
     Bob.Artifacts.add_docker_tag(
       "hexpm/elixir",
       "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
-      ["amd64"]
+      ["amd64", "arm64"]
     )
 
     :ok
@@ -49,7 +50,9 @@ defmodule BobWeb.DockerTagsLiveTest do
       })
 
     assert docker_tag?(html, "1.18.0-erlang-27.0-ubuntu-noble-20250101")
+    assert docker_tag?(html, "1.18.1-erlang-27.0-ubuntu-noble-20250101")
     refute docker_tag?(html, "27.0-ubuntu-noble-20250101")
+    refute docker_tag?(html, "1.17.3-erlang-26.2-debian-bookworm-20250113-slim")
   end
 
   test "flags tags reserved by a build request", %{conn: conn} do

--- a/test/bob_web/public_api_test.exs
+++ b/test/bob_web/public_api_test.exs
@@ -61,10 +61,11 @@ defmodule BobWeb.PublicApiTest do
 
   describe "/docker" do
     setup %{conn: conn} do
-      Bob.Artifacts.add_docker_tag("hexpm/erlang", "27.0-ubuntu-noble-20250101", [
-        "amd64",
-        "arm64"
-      ])
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang",
+        "27.0-ubuntu-noble-20250101",
+        ["amd64", "arm64"]
+      )
 
       Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
@@ -75,7 +76,7 @@ defmodule BobWeb.PublicApiTest do
       Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
         "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
-        ["amd64"]
+        ["amd64", "arm64"]
       )
 
       {:ok, conn: put_req_header(conn, "accept", "application/json")}
@@ -104,6 +105,24 @@ defmodule BobWeb.PublicApiTest do
 
       assert body["total"] == 1
       assert Enum.map(body["tags"], & &1["tag"]) == ["1.18.0-erlang-27.0-ubuntu-noble-20250101"]
+    end
+
+    test "filters by arch", %{conn: conn} do
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/erlang-amd64",
+        "27.1-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      body = conn |> get(~p"/api/docker?arch=arm64") |> json_response(200)
+
+      assert body["total"] == 3
+      refute "27.1-ubuntu-noble-20250101" in Enum.map(body["tags"], & &1["tag"])
+
+      body = conn |> get(~p"/api/docker?arch=amd64") |> json_response(200)
+
+      assert body["total"] == 4
+      assert "27.1-ubuntu-noble-20250101" in Enum.map(body["tags"], & &1["tag"])
     end
 
     test "filters by structured params", %{conn: conn} do


### PR DESCRIPTION
## Summary

In real releases, images in `hexpm/erlang` and `hexpm/elixir` are (usually¹) manifest lists spanning all supported architectures (`amd64` and `arm64`), while single-arch images are pushed to per-arch repositories (`hexpm/erlang-amd64`, etc.).

Update the test fixtures across the test suite to use dual-arch manifests for `hexpm/erlang` and `hexpm/elixir`, use per-arch repositories for single-arch test cases (`hexpm/erlang-amd64`, `hexpm/elixir-arm64`), add arch filtering coverage to the public Docker API tests, and reformat `add_docker_tag` invocations to a consistent multi-line style.

This is related to working on #289, to avoid conflating test changes with the intended change in API behavior to solve that issue. This PR should carry no behavior change. (This would be a good candidate for PR stacks if it supported cross-fork branches.)

---

¹ It it possible that `hexpm/erlang` will temporarily contain a single-arch manifest until reconciled later.

## Testing

```
mix format --check-formatted
mix test
```
