### PR TITLE
Prevent premature registration of unpushed Docker tags

### DIFF
--- a/priv/scripts/docker/elixir.sh
+++ b/priv/scripts/docker/elixir.sh
@@ -22,4 +22,4 @@ docker push docker.io/hexpm/elixir-${arch}:${tag} ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/elixir-${arch}:${tag}) ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/elixir-${arch}:${tag}) ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/elixir-${arch}:${tag}) ||
-  (exit 0)
+  (exit 1)

--- a/priv/scripts/docker/erlang.sh
+++ b/priv/scripts/docker/erlang.sh
@@ -57,4 +57,4 @@ docker push docker.io/hexpm/erlang-${arch}:${tag} ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/erlang-${arch}:${tag}) ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/erlang-${arch}:${tag}) ||
   (sleep $((20 + $RANDOM % 40)) && docker push docker.io/hexpm/erlang-${arch}:${tag}) ||
-  (exit 0)
+  (exit 1)


### PR DESCRIPTION
## Summary

While working on #289, I noticed that the API / `/docker` UI may return image tags that were never successfully pushed to Docker Hub.

If downstream code would come across such tags, it would be confusing to handle the "ghost" image tag on the client side. Careful clients would need to query the Docker Hub API or attempt a pull, which is exactly the thing that tends to fail because of transient availability issues and why those clients want to rely on Bob instead of Docker Hub.

---

When `priv/scripts/docker/elixir.sh` and `priv/scripts/docker/erlang.sh` exhaust their 5 retry attempts pushing to Docker Hub, they ended with `(exit 0)`.

Because the scripts returned exit status 0, `Bob.Script.run/3` treated the execution as successful. The calling job (`BuildDockerElixir` or `BuildDockerErlang`) then proceeded to invoke `Bob.RemoteQueue.docker_add/3`, registering the tag in the PostgreSQL `docker_tags` table despite the image never landing on Docker Hub.

This caused several issues:
1. Phantom tags: The Public API (`/api/docker`) and LiveView (`/docker`) advertised images as available when they did not exist on Docker Hub.
2. Suppressed retries: `Bob.Job.DockerChecker` relies on existing tag records to determine what has already been built; registering an unpushed tag prevented `DockerChecker` from re-enqueuing the build job until nightly reconciliation.
3. Incomplete manifests: Subsequent `Bob.Job.DockerManifest` jobs either built single-arch manifests or skipped manifest publication entirely.

History & Evolution:
- In May 2020 (98a64c9, "Cool it with the docker pushes"), `(exit 0)` was added to `elixir.sh`, `erlang.sh`, and `manifest.sh` to prevent transient Docker Hub push errors from failing build jobs.
- In May 2023 (a9afd5b, "Fail manifest"), `manifest.sh` was updated to `(exit 1)` so that failed manifest creation would surface as an error, while `elixir.sh` and `erlang.sh` retained the `(exit 0)` fallback.

Why change to `(exit 1)` and consequences for future jobs:
- Changing `(exit 0)` to `(exit 1)` ensures that when all push attempts fail, the shell script terminates with a non-zero exit code.
- `Bob.Script.run/3` will raise a `%Porcelain.Result{status: 1}` error, failing the job and logging the failure in `Bob.Runner`.
- `Bob.RemoteQueue.docker_add/3` is never reached, preventing the tag from being inserted into PostgreSQL.
- On subsequent runs, `Bob.Job.DockerChecker` will see the tag missing and automatically re-enqueue the build job.


## Testing

These shell scripts depend on live Docker daemon operations and external Docker Hub network pushes, so push failure paths are not directly exercised by the unit test suite. Verified via script analysis, shell exit code behavior, and running `mix test --warnings-as-errors`.
