### PR TITLE
Repo exact match

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -74,13 +74,16 @@ Example response, with all but the first matching artifact omitted:
 
 ## Docker tags
 
-`GET /api/docker` searches tags in the Hex Docker repositories. Each filter uses a case-sensitive prefix match.
+`GET /api/docker` searches tags in the Hex Docker repositories. The `repo` filter uses an exact match; all other filters use a case-sensitive prefix match.
+
+> [!NOTE]
+> An earlier version of the API used prefix matching on `repo` (e.g. `repo=hexpm/elixir` matching `hexpm/elixir-amd64` and `hexpm/elixir-arm64`). To fetch tags across multiple repositories, omit the `repo` filter or make separate queries for each repository.
 
 ### Query parameters
 
 | Parameter | Matching behavior |
 | --- | --- |
-| `repo` | Prefix match against the repository name. For example, `hexpm/elixir` also matches `hexpm/elixir-amd64` and `hexpm/elixir-arm64`. |
+| `repo` | Exact match against the repository name. For example, `hexpm/elixir` matches only `hexpm/elixir`, excluding per-arch repositories like `hexpm/elixir-amd64`. |
 | `tag` | Prefix match against the full Docker tag. |
 | `arch` | Prefix match against any architecture provided by the tag. |
 | `elixir_version` | Prefix match against the Elixir version parsed from the tag. |

--- a/lib/bob/artifacts.ex
+++ b/lib/bob/artifacts.ex
@@ -312,7 +312,7 @@ defmodule Bob.Artifacts do
 
   defp docker_tag_search_query(filters) do
     DockerTag
-    |> prefix_filter(:repo, Map.get(filters, :repo))
+    |> eq_filter(:repo, Map.get(filters, :repo))
     |> prefix_filter(:tag, Map.get(filters, :tag))
     |> arch_prefix_filter(Map.get(filters, :arch))
     |> search_metadata_prefix_filter(:elixir_version, Map.get(filters, :elixir_version))

--- a/priv/repo/migrations/20260824203718_drop_docker_tags_repo_prefix_index.exs
+++ b/priv/repo/migrations/20260824203718_drop_docker_tags_repo_prefix_index.exs
@@ -1,0 +1,16 @@
+defmodule Bob.Repo.Migrations.DropDockerTagsRepoPrefixIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS docker_tags_repo_prefix_index")
+  end
+
+  def down do
+    execute(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS docker_tags_repo_prefix_index ON docker_tags (repo text_pattern_ops)"
+    )
+  end
+end

--- a/test/bob/artifacts_test.exs
+++ b/test/bob/artifacts_test.exs
@@ -931,6 +931,12 @@ defmodule Bob.ArtifactsTest do
       )
 
       Bob.Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
+      Bob.Artifacts.add_docker_tag(
         "hexpm/elixir",
         "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
         ["amd64", "arm64"]
@@ -938,7 +944,7 @@ defmodule Bob.ArtifactsTest do
 
       assert [%{tag: "27.0-ubuntu-noble-20250101"}] =
                Bob.Artifacts.search_docker_tags(%{
-                 repo: "hexpm/erl",
+                 repo: "hexpm/erlang",
                  tag: "27",
                  arch: "arm",
                  erlang_version: "27",
@@ -948,15 +954,18 @@ defmodule Bob.ArtifactsTest do
 
       assert [%{tag: "27.0-ubuntu-noble-20250101"}] =
                Bob.Artifacts.search_docker_tags(%{
-                 repo: "hexpm/erl",
+                 repo: "hexpm/erlang",
                  tag: "27",
                  arch: "arm",
                  os: "ub",
                  os_version: "noble"
                })
 
+      assert [] = Bob.Artifacts.search_docker_tags(%{repo: "hexpm/erl"})
+
       assert [
                "1.17.3-erlang-26.2-debian-bookworm-20250113-slim",
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101",
                "1.18.0-erlang-27.0-ubuntu-noble-20250101"
              ] =
                Bob.Artifacts.search_docker_tags(%{elixir_version: "1"})
@@ -965,6 +974,7 @@ defmodule Bob.ArtifactsTest do
 
       assert [
                "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101",
                "27.0-ubuntu-noble-20250101",
                "27.1-ubuntu-noble-20250101"
              ] =
@@ -972,11 +982,16 @@ defmodule Bob.ArtifactsTest do
                |> Enum.map(& &1.tag)
                |> Enum.sort()
 
-      assert [%{tag: "1.18.0-erlang-27.0-ubuntu-noble-20250101"}] =
+      assert [
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101"
+             ] =
                Bob.Artifacts.search_docker_tags(%{
                  elixir_version: "1",
                  os: "ub"
                })
+               |> Enum.map(& &1.tag)
+               |> Enum.sort()
 
       assert [%{tag: "1.18.0-erlang-27.0-ubuntu-noble-20250101"}] =
                Bob.Artifacts.search_docker_tags(%{
@@ -993,6 +1008,11 @@ defmodule Bob.ArtifactsTest do
                  os: "deb",
                  os_version: "bookworm"
                })
+
+      elixir_results = Bob.Artifacts.search_docker_tags(%{repo: "hexpm/elixir"})
+      assert length(elixir_results) == 2
+      assert Enum.all?(elixir_results, &(&1.repo == "hexpm/elixir"))
+      refute Enum.any?(elixir_results, &(&1.repo == "hexpm/elixir-amd64"))
     end
 
     test "count_docker_tags/1 counts exact matching tags" do
@@ -1012,7 +1032,7 @@ defmodule Bob.ArtifactsTest do
 
       count =
         Bob.Artifacts.count_docker_tags(%{
-          repo: "hexpm/erl",
+          repo: "hexpm/erlang",
           tag: "27",
           arch: "arm",
           erlang_version: "27",
@@ -1021,6 +1041,7 @@ defmodule Bob.ArtifactsTest do
         })
 
       assert count == 2
+      assert Bob.Artifacts.count_docker_tags(%{repo: "hexpm/erl"}) == 0
       assert Bob.Artifacts.count_docker_tags(%{arch: "amd64"}) == 1
       assert Bob.Artifacts.count_docker_tags(%{arch: "arm64"}) == 2
       assert Bob.Artifacts.count_docker_tags(%{tag: "missing"}) == 0

--- a/test/bob_web/live/docker_tags_live_test.exs
+++ b/test/bob_web/live/docker_tags_live_test.exs
@@ -28,6 +28,12 @@ defmodule BobWeb.DockerTagsLiveTest do
       ["amd64", "arm64"]
     )
 
+    Bob.Artifacts.add_docker_tag(
+      "hexpm/elixir-amd64",
+      "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+      ["amd64"]
+    )
+
     :ok
   end
 
@@ -35,8 +41,8 @@ defmodule BobWeb.DockerTagsLiveTest do
     {:ok, view, html} = live(conn, ~p"/docker")
     assert html =~ "27.0-ubuntu-noble-20250101"
     assert html =~ "1.18.0-erlang-27.0-ubuntu-noble-20250101"
-    assert html =~ "4 tags"
-    assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>4<\/b>\s*tags\s*of\s*4 tags/
+    assert html =~ "5 tags"
+    assert html =~ ~r/Showing\s*<b>1<\/b>\s*-\s*<b>5<\/b>\s*tags\s*of\s*5 tags/
 
     html =
       render_change(view, "search", %{
@@ -53,6 +59,27 @@ defmodule BobWeb.DockerTagsLiveTest do
     assert docker_tag?(html, "1.18.1-erlang-27.0-ubuntu-noble-20250101")
     refute docker_tag?(html, "27.0-ubuntu-noble-20250101")
     refute docker_tag?(html, "1.17.3-erlang-26.2-debian-bookworm-20250113-slim")
+  end
+
+  test "filters by exact repo match", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/docker")
+
+    html =
+      render_change(view, "search", %{
+        "repo" => "hexpm/elixir",
+        "tag" => "",
+        "arch" => "",
+        "elixir_version" => "",
+        "erlang_version" => "",
+        "os" => "",
+        "os_version" => ""
+      })
+
+    assert html =~ "2 tags"
+    assert docker_tag?(html, "1.18.0-erlang-27.0-ubuntu-noble-20250101")
+    assert docker_tag?(html, "1.17.3-erlang-26.2-debian-bookworm-20250113-slim")
+    refute docker_tag?(html, "1.18.1-erlang-27.0-ubuntu-noble-20250101")
+    refute docker_tag?(html, "27.0-ubuntu-noble-20250101")
   end
 
   test "flags tags reserved by a build request", %{conn: conn} do

--- a/test/bob_web/public_api_test.exs
+++ b/test/bob_web/public_api_test.exs
@@ -79,13 +79,19 @@ defmodule BobWeb.PublicApiTest do
         ["amd64", "arm64"]
       )
 
+      Bob.Artifacts.add_docker_tag(
+        "hexpm/elixir-amd64",
+        "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+        ["amd64"]
+      )
+
       {:ok, conn: put_req_header(conn, "accept", "application/json")}
     end
 
     test "returns all tags as JSON", %{conn: conn} do
       body = conn |> get(~p"/api/docker") |> json_response(200)
 
-      assert body["total"] == 3
+      assert body["total"] == 4
       assert body["offset"] == 0
       assert body["page_size"] == 100
 
@@ -103,8 +109,12 @@ defmodule BobWeb.PublicApiTest do
     test "filters by tag prefix like the LiveView", %{conn: conn} do
       body = conn |> get(~p"/api/docker?tag=1.18") |> json_response(200)
 
-      assert body["total"] == 1
-      assert Enum.map(body["tags"], & &1["tag"]) == ["1.18.0-erlang-27.0-ubuntu-noble-20250101"]
+      assert body["total"] == 2
+
+      assert Enum.map(body["tags"], & &1["tag"]) == [
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101",
+               "1.18.0-erlang-27.0-ubuntu-noble-20250101"
+             ]
     end
 
     test "filters by arch", %{conn: conn} do
@@ -121,7 +131,7 @@ defmodule BobWeb.PublicApiTest do
 
       body = conn |> get(~p"/api/docker?arch=amd64") |> json_response(200)
 
-      assert body["total"] == 4
+      assert body["total"] == 5
       assert "27.1-ubuntu-noble-20250101" in Enum.map(body["tags"], & &1["tag"])
     end
 
@@ -132,6 +142,25 @@ defmodule BobWeb.PublicApiTest do
         |> json_response(200)
 
       assert Enum.map(body["tags"], & &1["tag"]) == ["1.18.0-erlang-27.0-ubuntu-noble-20250101"]
+    end
+
+    test "filters by exact repo match, excluding other repos sharing prefix", %{conn: conn} do
+      body =
+        conn
+        |> get(~p"/api/docker?repo=hexpm/elixir")
+        |> json_response(200)
+
+      assert body["total"] == 2
+      assert Enum.all?(body["tags"], &(&1["repo"] == "hexpm/elixir"))
+      refute Enum.any?(body["tags"], &(&1["repo"] == "hexpm/elixir-amd64"))
+
+      prefix_body =
+        conn
+        |> get(~p"/api/docker?repo=hexpm/elix")
+        |> json_response(200)
+
+      assert prefix_body["total"] == 0
+      assert prefix_body["tags"] == []
     end
 
     test "sorts by multiple parsed fields", %{conn: conn} do
@@ -161,7 +190,7 @@ defmodule BobWeb.PublicApiTest do
     test "defaults malformed sort params to build time", %{conn: conn} do
       body = conn |> get("/api/docker?sort[]=os") |> json_response(200)
 
-      assert body["total"] == 3
+      assert body["total"] == 4
     end
 
     test "treats build time as an exclusive sort", %{conn: conn} do
@@ -196,7 +225,7 @@ defmodule BobWeb.PublicApiTest do
         |> get(~p"/api/docker?tag=1&erlang_version=26&os=debian")
         |> json_response(200)
 
-      assert body["total"] == 2
+      assert body["total"] == 3
     end
   end
 end


### PR DESCRIPTION
## Summary

The Docker tags query previously filtered repo using prefix matching (`LIKE 'repo%'`), which meant queries for `hexpm/elixir` also matched per-arch repositories like `hexpm/elixir-amd64`.

Switch the repository filter to an exact equality match (`eq_filter(:repo, ...)`), drop the `docker_tags_repo_prefix_index` index now that equality queries use existing composite indexes, and update documentation and API/LiveView tests.

Closes #289.

Builds on top of #291 (merged).

~May change depending on feedback on https://github.com/hexpm/bob/issues/289#issuecomment-5407764435, if we decide to bundle multiple API changes together:~

<details>

- Exact match on `os`
- Exact match on `arch`
- Optional list of strings on `arch` (meaning multi-arch tag with all specified archs)
- Version-aware prefix matching for `elixir_version` and `erlang_version`

</details>

Update: further API improvements extracted to separate issues: https://github.com/hexpm/bob/issues/294, https://github.com/hexpm/bob/issues/295, https://github.com/hexpm/bob/issues/296.

## Testing

```
mix format --check-formatted
mix test
```
