### PR TITLE
Track Sentry releases by image git sha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
       PROJECT_ID: 'hexpm-prod'
       SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
       WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCLOUD_WORKFLOW_IDENTITY_POOL_PROVIDER }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -103,3 +104,23 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The release version is the image tag; the app sends the same value
+      # from the baked GIT_SHA, and the hexpm-ops deploy registers when it
+      # reaches an environment. The refs association needs the repository
+      # linked to the Sentry GitHub integration; fall back to a bare release
+      # so a missing link degrades commit tracking, not CI.
+      - name: Create Sentry release
+        if: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' && env.SENTRY_AUTH_TOKEN != '' }}
+        run: |
+          api="https://sentry.io/api/0/organizations/hexpm/releases/"
+          refs_payload=$(printf '{"version": "%s", "projects": ["bob"], "refs": [{"repository": "hexpm/bob", "commit": "%s"}]}' "$COMMIT_SHORT_SHA" "$GITHUB_SHA")
+          bare_payload=$(printf '{"version": "%s", "projects": ["bob"]}' "$COMMIT_SHORT_SHA")
+          curl -sf -X POST "$api" \
+            -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$refs_payload" ||
+            curl -sf -X POST "$api" \
+              -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$bare_payload"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,9 +34,19 @@ if config_env() == :prod do
     access_key_id: System.fetch_env!("BOB_S3_ACCESS_KEY"),
     secret_access_key: System.fetch_env!("BOB_S3_SECRET_KEY")
 
+  # GIT_SHA is baked into the image and matches the release CI creates in
+  # Sentry, so issues resolved via commits auto-resolve when the deploy
+  # carrying the fix is registered.
+  sentry_release =
+    case System.get_env("GIT_SHA") do
+      sha when sha in [nil, "", "unknown"] -> nil
+      sha -> sha
+    end
+
   config :sentry,
     dsn: System.fetch_env!("BOB_SENTRY_DSN"),
     environment_name: System.fetch_env!("BOB_ENV"),
+    release: sentry_release,
     tags: %{
       bob_who: System.fetch_env!("BOB_WHO"),
       bob_hostname: System.fetch_env!("BOB_HOSTNAME")


### PR DESCRIPTION
Same wiring as hexpm/hexpm: the SDK sends the baked GIT_SHA as the release and the docker CI job creates the matching Sentry release with a commit ref when it pushes the image; hexpm-ops registers the deploy when the tag reaches the cluster. Skipped until the SENTRY_AUTH_TOKEN secret from hexpm-ops#292 exists.