### PR TITLE
Raise clean errors when upstream requests exhaust retries

### DIFF
--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -68,6 +68,12 @@ defmodule Bob.DockerHub do
 
       {:ok, 404, _headers, _body} ->
         :not_found
+
+      {:ok, status, _headers, _body} ->
+        raise "DockerHub #{url} returned status #{status} after retries"
+
+      {:error, reason} ->
+        raise "DockerHub #{url} failed after retries: #{inspect(reason)}"
     end
   end
 

--- a/lib/bob/github.ex
+++ b/lib/bob/github.ex
@@ -52,10 +52,18 @@ defmodule Bob.GitHub do
 
     opts = if user && token, do: [basic_auth: {user, token}], else: []
 
-    {:ok, 200, headers, body} =
-      Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
+    result = Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
 
-    {JSON.decode!(body), headers}
+    case result do
+      {:ok, 200, headers, body} ->
+        {JSON.decode!(body), headers}
+
+      {:ok, status, _headers, _body} ->
+        raise "GitHub #{url} returned status #{status} after retries"
+
+      {:error, reason} ->
+        raise "GitHub #{url} failed after retries: #{inspect(reason)}"
+    end
   end
 
   defp next_link(headers) do


### PR DESCRIPTION
github_get pattern-matched on 200 and fetch_tag's case had no clause for 5xx, so a GitHub 503 or DockerHub 500 that survived the retry loop crashed as a MatchError or CaseClauseError with the full response headers in the message, fingerprinting every upstream incident as a new Sentry issue (BOB-1F was 348 events in one day, plus the BOB-46/4C GitHub 503 pair). Both now raise a stable one-line error naming the URL and status. Fixes BOB-1F.