### PR TITLE
Count refused checkouts and connection churn as metrics

### DIFF
--- a/lib/bob/application.ex
+++ b/lib/bob/application.ex
@@ -41,7 +41,8 @@ defmodule Bob.Application do
 
   defp repo_children() do
     if Application.get_env(:bob, :master?) do
-      [Bob.Repo] ++ maintenance_children()
+      [{DBConnection.TelemetryListener, name: Bob.Repo.TelemetryListener}, Bob.Repo] ++
+        maintenance_children()
     else
       []
     end

--- a/lib/bob/prom_ex.ex
+++ b/lib/bob/prom_ex.ex
@@ -17,7 +17,7 @@ defmodule Bob.PromEx do
   # Agents run without Bob.Repo, so the Ecto plugin would crash them
   defp master_plugins() do
     if Application.get_env(:bob, :master?) do
-      [{Plugins.Ecto, repos: [Bob.Repo]}]
+      [{Plugins.Ecto, repos: [Bob.Repo]}, Bob.PromEx.Plugins.DbConnection]
     else
       []
     end

--- a/lib/bob/prom_ex/plugins/db_connection.ex
+++ b/lib/bob/prom_ex/plugins/db_connection.ex
@@ -1,0 +1,45 @@
+defmodule Bob.PromEx.Plugins.DbConnection do
+  @moduledoc """
+  PromEx plugin for the database connection pool: refused checkouts and
+  connection churn.
+
+  `[:db_connection, :connection_error]` fires where the pool gives up on a
+  checkout. The reason is `:queue_timeout` when the caller waited out the queue
+  and `:error` when there was no connection to wait for. Connects and
+  disconnects come from the `DBConnection.TelemetryListener` the repo is
+  started with.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    metric_prefix =
+      Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :db_connection))
+
+    Event.build(:bob_db_connection_event_metrics, [
+      counter(
+        metric_prefix ++ [:connection_error, :total],
+        event_name: [:db_connection, :connection_error],
+        description: "Connection checkouts the pool refused, by reason.",
+        tags: [:reason],
+        tag_values: &__MODULE__.error_tags/1
+      ),
+      counter(
+        metric_prefix ++ [:connected, :total],
+        event_name: [:db_connection, :connected],
+        description: "Database connections established."
+      ),
+      counter(
+        metric_prefix ++ [:disconnected, :total],
+        event_name: [:db_connection, :disconnected],
+        description: "Database connections lost or closed."
+      )
+    ])
+  end
+
+  def error_tags(%{error: %DBConnection.ConnectionError{reason: reason}}), do: %{reason: reason}
+  def error_tags(_metadata), do: %{reason: :unknown}
+end

--- a/lib/bob/repo.ex
+++ b/lib/bob/repo.ex
@@ -4,6 +4,8 @@ defmodule Bob.Repo do
     adapter: Ecto.Adapters.Postgres
 
   def init(_context, opts) do
+    opts = put_connection_listener(opts)
+
     if url = System.get_env("BOB_DATABASE_URL") do
       pool_size_env = System.get_env("BOB_DATABASE_POOL_SIZE")
       pool_size = if pool_size_env, do: String.to_integer(pool_size_env), else: opts[:pool_size]
@@ -38,6 +40,17 @@ defmodule Bob.Repo do
       {:ok, opts}
     else
       {:ok, opts}
+    end
+  end
+
+  # The listener runs in the application tree. A repo started on its own, as
+  # the release tasks do, has nobody to notify, and a name that is not
+  # registered would crash every connection that tries.
+  defp put_connection_listener(opts) do
+    if Process.whereis(__MODULE__.TelemetryListener) do
+      Keyword.put(opts, :connection_listeners, {[__MODULE__.TelemetryListener], __MODULE__})
+    else
+      opts
     end
   end
 

--- a/test/bob/prom_ex/plugins/db_connection_test.exs
+++ b/test/bob/prom_ex/plugins/db_connection_test.exs
@@ -1,0 +1,54 @@
+defmodule Bob.PromEx.Plugins.DbConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias Bob.PromEx.Plugins.DbConnection
+
+  test "tags a refused checkout by its reason" do
+    error = DBConnection.ConnectionError.exception("connection not available", :queue_timeout)
+
+    assert DbConnection.error_tags(%{error: error}) == %{reason: :queue_timeout}
+  end
+
+  test "counts an error without a reason rather than dropping it" do
+    assert DbConnection.error_tags(%{error: :closed}) == %{reason: :unknown}
+  end
+
+  test "attaches to the pool and listener events" do
+    events =
+      [otp_app: :bob]
+      |> DbConnection.event_metrics()
+      |> List.wrap()
+      |> Enum.flat_map(& &1.metrics)
+      |> Enum.map(& &1.event_name)
+      |> Enum.uniq()
+
+    assert [:db_connection, :connection_error] in events
+    assert [:db_connection, :connected] in events
+    assert [:db_connection, :disconnected] in events
+  end
+
+  test "the repo notifies the listener the application started" do
+    assert Bob.Repo.config()[:connection_listeners] ==
+             {[Bob.Repo.TelemetryListener], Bob.Repo}
+  end
+
+  test "the listener reports connections the repo opens and closes" do
+    ref = make_ref()
+    parent = self()
+
+    :telemetry.attach_many(
+      {__MODULE__, ref},
+      [[:db_connection, :connected], [:db_connection, :disconnected]],
+      fn event, _measurements, metadata, _config -> send(parent, {ref, event, metadata.tag}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    {:ok, repo} = Bob.Repo.start_link(name: __MODULE__.Repo, pool_size: 1)
+    assert_receive {^ref, [:db_connection, :connected], Bob.Repo}, 5_000
+
+    Supervisor.stop(repo)
+    assert_receive {^ref, [:db_connection, :disconnected], Bob.Repo}, 5_000
+  end
+end

--- a/test/bob/repo_test.exs
+++ b/test/bob/repo_test.exs
@@ -6,8 +6,9 @@ defmodule Bob.RepoTest do
   end
 
   describe "init/2" do
-    test "leaves opts unchanged without BOB_DATABASE_URL" do
-      assert Bob.Repo.init(:supervisor, pool_size: 3) == {:ok, [pool_size: 3]}
+    test "adds only the connection listener without BOB_DATABASE_URL" do
+      assert Bob.Repo.init(:supervisor, pool_size: 3) ==
+               {:ok, connection_listeners: {[Bob.Repo.TelemetryListener], Bob.Repo}, pool_size: 3}
     end
 
     test "applies url and pool_size from the environment without ssl when no CA cert" do


### PR DESCRIPTION
DBConnection emits `[:db_connection, :connection_error]` where the pool gives up on a checkout, with the reason (`:queue_timeout` or `:error`), and `DBConnection.TelemetryListener` emits `connected` and `disconnected` for every connection process. A PromEx plugin turns them into three counters (connection errors by reason, connections established, connections lost) so a saturated pool or a connection storm can be alerted on from Prometheus instead of from the log-line policies in Cloud Monitoring.

The listener runs in the application supervision tree and the repo only registers it when the listener process is running: a repo started on its own, as the release tasks do, would otherwise crash every connection on `send/2` to an unregistered name.

The Prometheus rules that read these counters are in hexpm/hexpm-ops#300.
