### PR TITLE
Track final HTTP outcomes and tolerate Docker Hub failures

### DIFF
--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -16,8 +16,10 @@ defmodule Bob.DockerHub do
     opts = [recv_timeout: 10_000]
 
     {:ok, 200, _headers, body} =
-      Bob.HTTP.retry("DockerHub #{url}", fn ->
-        Bob.HTTP.request(:post, url, headers, JSON.encode!(body), opts)
+      track_request(:post, fn ->
+        Bob.HTTP.retry("DockerHub #{url}", fn ->
+          Bob.HTTP.request(:post, url, headers, JSON.encode!(body), opts)
+        end)
       end)
 
     result = JSON.decode!(body)
@@ -44,36 +46,27 @@ defmodule Bob.DockerHub do
   @doc """
   Fetches a tag as `{:ok, {name, archs, built_at}}`.
 
-  `:not_found` is Docker Hub saying the tag is gone. `:unreadable` is a response
-  that carried no usable image data, which says nothing about the tag either
-  way — callers deciding what an image should contain have to tell the two
-  apart.
+  `:not_found` means Docker Hub returned 404. `:unreadable` means the request
+  failed after retries or returned no usable image data. Callers must preserve
+  existing manifests when a tag is unreadable.
   """
-  def fetch_tag(repo, tag) do
+  def fetch_tag(repo, tag, opts \\ []) do
     url = @dockerhub_url <> "v2/repositories/#{repo}/tags/#{tag}"
-    headers = headers()
-    opts = [recv_timeout: 20_000]
 
-    result =
-      Bob.HTTP.retry("DockerHub #{url}", fn ->
-        Bob.HTTP.request(:get, url, headers, "", opts)
-      end)
-
-    case result do
+    case paced_request(:get, url, opts) do
       {:ok, 200, _headers, body} ->
-        case parse(JSON.decode!(body)) do
-          nil -> :unreadable
-          parsed -> {:ok, parsed}
+        with {:ok, decoded} when is_map(decoded) <- JSON.decode(body),
+             parsed when not is_nil(parsed) <- parse(decoded) do
+          {:ok, parsed}
+        else
+          _ -> :unreadable
         end
 
       {:ok, 404, _headers, _body} ->
         :not_found
 
-      {:ok, status, _headers, _body} ->
-        raise "DockerHub #{url} returned status #{status} after retries"
-
-      {:error, reason} ->
-        raise "DockerHub #{url} failed after retries: #{inspect(reason)}"
+      _other ->
+        :unreadable
     end
   end
 
@@ -102,33 +95,53 @@ defmodule Bob.DockerHub do
   other request. Every attempt reports back, so a failed one can't leave the
   gate holding a slot that is never returned.
   """
-  def paced_request(method, url), do: paced_request(method, url, 0)
+  def paced_request(method, url, opts \\ []) do
+    track_request(method, fn -> paced_request(method, url, 0, opts) end)
+  end
 
-  defp paced_request(method, url, attempts) do
+  defp paced_request(method, url, attempts, opts) do
+    request = Keyword.get(opts, :request, &Bob.HTTP.request/5)
+    limiter = Keyword.get(opts, :rate_limiter, RateLimiter)
+
     result =
       Bob.HTTP.retry(
         "DockerHub #{url}",
         fn ->
-          RateLimiter.acquire()
-          result = Bob.HTTP.request(method, url, headers(), "", recv_timeout: 20_000)
-          report(result)
+          RateLimiter.acquire(limiter)
+          result = request.(method, url, headers(), "", recv_timeout: 20_000)
+          report(result, limiter)
           result
         end,
-        retry_rate_limit?: false
+        Keyword.put(opts, :retry_rate_limit?, false)
       )
 
     case result do
       {:ok, 429, _response_headers, _body} when attempts < @max_rate_limit_retries ->
-        paced_request(method, url, attempts + 1)
+        paced_request(method, url, attempts + 1, opts)
 
       _other ->
         result
     end
   end
 
-  defp report({:ok, 429, response_headers, _body}), do: RateLimiter.throttle(response_headers)
-  defp report({:ok, _status, response_headers, _body}), do: RateLimiter.observe(response_headers)
-  defp report({:error, _reason}), do: RateLimiter.observe([])
+  defp track_request(method, fun) do
+    result = fun.()
+
+    :telemetry.execute([:bob, :docker_hub, :request, :stop], %{}, %{
+      method: method,
+      result: result
+    })
+
+    result
+  end
+
+  defp report({:ok, 429, response_headers, _body}, limiter),
+    do: RateLimiter.throttle(response_headers, limiter)
+
+  defp report({:ok, _status, response_headers, _body}, limiter),
+    do: RateLimiter.observe(response_headers, limiter)
+
+  defp report({:error, _reason}, limiter), do: RateLimiter.observe([], limiter)
 
   def headers() do
     if token = Application.get_env(:bob, :dockerhub_token) do

--- a/lib/bob/docker_hub.ex
+++ b/lib/bob/docker_hub.ex
@@ -16,7 +16,7 @@ defmodule Bob.DockerHub do
     opts = [recv_timeout: 10_000]
 
     {:ok, 200, _headers, body} =
-      track_request(:post, fn ->
+      Bob.HTTP.track_request(:post, url, fn ->
         Bob.HTTP.retry("DockerHub #{url}", fn ->
           Bob.HTTP.request(:post, url, headers, JSON.encode!(body), opts)
         end)
@@ -96,7 +96,7 @@ defmodule Bob.DockerHub do
   gate holding a slot that is never returned.
   """
   def paced_request(method, url, opts \\ []) do
-    track_request(method, fn -> paced_request(method, url, 0, opts) end)
+    Bob.HTTP.track_request(method, url, fn -> paced_request(method, url, 0, opts) end)
   end
 
   defp paced_request(method, url, attempts, opts) do
@@ -122,17 +122,6 @@ defmodule Bob.DockerHub do
       _other ->
         result
     end
-  end
-
-  defp track_request(method, fun) do
-    result = fun.()
-
-    :telemetry.execute([:bob, :docker_hub, :request, :stop], %{}, %{
-      method: method,
-      result: result
-    })
-
-    result
   end
 
   defp report({:ok, 429, response_headers, _body}, limiter),

--- a/lib/bob/fastly.ex
+++ b/lib/bob/fastly.ex
@@ -30,8 +30,10 @@ defmodule Bob.Fastly do
       {"surrogate-key", keys}
     ]
 
-    Bob.HTTP.retry("Fastly", fn ->
-      Bob.HTTP.request(:post, url, headers, "")
+    Bob.HTTP.track_request(:post, url, fn ->
+      Bob.HTTP.retry("Fastly", fn ->
+        Bob.HTTP.request(:post, url, headers, "")
+      end)
     end)
   end
 end

--- a/lib/bob/github.ex
+++ b/lib/bob/github.ex
@@ -52,7 +52,10 @@ defmodule Bob.GitHub do
 
     opts = if user && token, do: [basic_auth: {user, token}], else: []
 
-    result = Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
+    result =
+      Bob.HTTP.track_request(:get, url, fn ->
+        Bob.HTTP.retry("GitHub #{url}", fn -> Bob.HTTP.request(:get, url, [], "", opts) end)
+      end)
 
     case result do
       {:ok, 200, headers, body} ->

--- a/lib/bob/http.ex
+++ b/lib/bob/http.ex
@@ -49,7 +49,7 @@ defmodule Bob.HTTP do
         Logger.warning("#{name} ERROR: #{inspect(reason)}")
 
         if times + 1 < @max_retry_times do
-          Process.sleep(backoff(@error_sleep_time, times))
+          sleep(opts, backoff(@error_sleep_time, times))
           retry(name, fun, times + 1, opts)
         else
           {:error, reason}
@@ -63,7 +63,7 @@ defmodule Bob.HTTP do
           Logger.warning("#{name} RATE LIMIT")
 
           if times + 1 < @max_retry_times do
-            Process.sleep(backoff(@rate_limit_sleep_time, times))
+            sleep(opts, backoff(@rate_limit_sleep_time, times))
             retry(name, fun, times + 1, opts)
           else
             result
@@ -76,7 +76,7 @@ defmodule Bob.HTTP do
         Logger.warning("#{name} SERVER ERROR: #{status}")
 
         if times + 1 < @max_retry_times do
-          Process.sleep(backoff(@error_sleep_time, times))
+          sleep(opts, backoff(@error_sleep_time, times))
           retry(name, fun, times + 1, opts)
         else
           result
@@ -85,6 +85,11 @@ defmodule Bob.HTTP do
       result ->
         result
     end
+  end
+
+  defp sleep(opts, duration) do
+    sleep = Keyword.get(opts, :sleep, &Process.sleep/1)
+    sleep.(duration)
   end
 
   @doc false

--- a/lib/bob/http.ex
+++ b/lib/bob/http.ex
@@ -39,6 +39,28 @@ defmodule Bob.HTTP do
     {:error, reason}
   end
 
+  @doc """
+  Records one final HTTP outcome from `fun`, tagged by host and method.
+  Wrap the complete request operation, including any caller-managed retries.
+  """
+  def track_request(method, url, fun) do
+    result = fun.()
+
+    status =
+      case result do
+        {:ok, status, _headers, _body} -> status
+        {:error, _reason} -> "error"
+      end
+
+    :telemetry.execute([:bob, :http, :request, :stop], %{}, %{
+      host: URI.parse(url).host,
+      method: method |> to_string() |> String.upcase(),
+      status: status
+    })
+
+    result
+  end
+
   def retry(name, fun, opts \\ []) do
     retry(name, fun, 0, opts)
   end

--- a/lib/bob/prom_ex/plugins/outbound_http.ex
+++ b/lib/bob/prom_ex/plugins/outbound_http.ex
@@ -20,6 +20,12 @@ defmodule Bob.PromEx.Plugins.OutboundHttp do
       Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :outbound_http))
 
     Event.build(:bob_outbound_http_event_metrics, [
+      counter("bob.docker_hub.request.total",
+        event_name: [:bob, :docker_hub, :request, :stop],
+        description: "Docker Hub requests after all transport, server and rate-limit retries.",
+        tags: [:method, :status],
+        tag_values: &__MODULE__.docker_hub_tags/1
+      ),
       distribution(
         metric_prefix ++ [:request, :duration, :milliseconds],
         event_name: [:finch, :request, :stop],
@@ -75,6 +81,17 @@ defmodule Bob.PromEx.Plugins.OutboundHttp do
       method: request.method,
       status: status(Map.get(metadata, :result))
     }
+  end
+
+  @doc false
+  def docker_hub_tags(%{method: method, result: result}) do
+    status =
+      case result do
+        {:ok, status, _headers, _body} -> status
+        {:error, _reason} -> "error"
+      end
+
+    %{method: method |> to_string() |> String.upcase(), status: status}
   end
 
   @doc false

--- a/lib/bob/prom_ex/plugins/outbound_http.ex
+++ b/lib/bob/prom_ex/plugins/outbound_http.ex
@@ -20,11 +20,11 @@ defmodule Bob.PromEx.Plugins.OutboundHttp do
       Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :outbound_http))
 
     Event.build(:bob_outbound_http_event_metrics, [
-      counter("bob.docker_hub.request.total",
-        event_name: [:bob, :docker_hub, :request, :stop],
-        description: "Docker Hub requests after all transport, server and rate-limit retries.",
-        tags: [:method, :status],
-        tag_values: &__MODULE__.docker_hub_tags/1
+      counter(
+        metric_prefix ++ [:request, :final, :total],
+        event_name: [:bob, :http, :request, :stop],
+        description: "Final outbound HTTP outcomes after all retries at instrumented call sites.",
+        tags: [:host, :method, :status]
       ),
       distribution(
         metric_prefix ++ [:request, :duration, :milliseconds],
@@ -81,17 +81,6 @@ defmodule Bob.PromEx.Plugins.OutboundHttp do
       method: request.method,
       status: status(Map.get(metadata, :result))
     }
-  end
-
-  @doc false
-  def docker_hub_tags(%{method: method, result: result}) do
-    status =
-      case result do
-        {:ok, status, _headers, _body} -> status
-        {:error, _reason} -> "error"
-      end
-
-    %{method: method |> to_string() |> String.upcase(), status: status}
   end
 
   @doc false

--- a/lib/bob/remote_queue.ex
+++ b/lib/bob/remote_queue.ex
@@ -111,7 +111,12 @@ defmodule Bob.RemoteQueue do
     headers = [{"authorization", secret}, {"content-type", "application/vnd.bob+erlang"}]
     body = Bob.Plug.ErlangFormat.encode_to_iodata!(body)
 
-    case Bob.HTTP.retry("BobMaster", fn -> Bob.HTTP.request(:post, url, headers, body) end) do
+    result =
+      Bob.HTTP.track_request(:post, url, fn ->
+        Bob.HTTP.retry("BobMaster", fn -> Bob.HTTP.request(:post, url, headers, body) end)
+      end)
+
+    case result do
       {:ok, 200, _headers, body} ->
         {:ok, body} = Bob.Plug.ErlangFormat.decode(body)
         {:ok, body}

--- a/test/bob/docker_hub_test.exs
+++ b/test/bob/docker_hub_test.exs
@@ -48,6 +48,150 @@ defmodule Bob.DockerHubTest do
     end
   end
 
+  describe "requests" do
+    setup do
+      handler = {__MODULE__, make_ref()}
+
+      :telemetry.attach(
+        handler,
+        [:bob, :docker_hub, :request, :stop],
+        &__MODULE__.request_event/4,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "paces every attempt and counts a recovered request once" do
+      metric =
+        [otp_app: :bob]
+        |> Bob.PromEx.Plugins.OutboundHttp.event_metrics()
+        |> Map.fetch!(:metrics)
+        |> Enum.find(&(&1.name == [:bob, :docker_hub, :request, :total]))
+
+      start_supervised!(
+        {TelemetryMetricsPrometheus.Core,
+         name: __MODULE__.Metrics, metrics: [metric], start_async: false}
+      )
+
+      body =
+        JSON.encode!(
+          tag_payload(%{
+            "last_updated" => "2025-01-02T03:04:05.123456Z",
+            "images" => [image("amd64", "sha256:amd64", "2025-02-03T04:05:06Z")]
+          })
+        )
+
+      success = {:ok, 200, [], body}
+      opts = request_opts([{:error, :closed}, {:ok, 503, [], ""}, success])
+
+      assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) ==
+               {:ok, {"27.0", ["amd64"], @built_at}}
+
+      for _ <- 1..3 do
+        assert_receive {:attempt, :get,
+                        "https://hub.docker.com/v2/repositories/hexpm/erlang/tags/27.0", "",
+                        [recv_timeout: 20_000]}
+      end
+
+      assert :sys.get_state(opts[:rate_limiter]).sent_total == 3
+      assert_receive {:request_result, %{method: :get, result: ^success}}
+      refute_receive {:request_result, _}
+      refute_receive {:attempt, _, _, _, _}
+
+      metrics = TelemetryMetricsPrometheus.Core.scrape(__MODULE__.Metrics)
+      assert metrics =~ ~s(bob_docker_hub_request_total{method="GET",status="200"} 1)
+      refute metrics =~ ~s(status="503")
+      refute metrics =~ ~s(status="error")
+    end
+
+    for failure <- [{:ok, 503, [], ""}, {:error, :timeout}] do
+      test "returns unreadable and records one result after exhausting #{inspect(failure)}" do
+        failure = unquote(Macro.escape(failure))
+        opts = request_opts(List.duplicate(failure, 10))
+
+        assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
+        for _ <- 1..10, do: assert_receive({:attempt, :get, _, _, _})
+        assert_receive {:request_result, %{method: :get, result: ^failure}}
+        refute_receive {:request_result, _}
+        refute_receive {:attempt, _, _, _, _}
+      end
+    end
+
+    test "counts a rate-limited request once after it recovers" do
+      success = {:ok, 204, [], ""}
+      opts = request_opts([{:ok, 429, [], ""}, success])
+
+      assert DockerHub.paced_request(:delete, "https://hub.docker.com/tag", opts) == success
+      assert_receive {:request_result, %{method: :delete, result: ^success}}
+      assert :sys.get_state(opts[:rate_limiter]).sent_total == 2
+      refute_receive {:request_result, _}
+    end
+
+    test "stops after exhausting rate-limit retries" do
+      failure = {:ok, 429, [], ""}
+      opts = request_opts(List.duplicate(failure, 6))
+
+      assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
+      assert :sys.get_state(opts[:rate_limiter]).sent_total == 6
+      assert_receive {:request_result, %{result: ^failure}}
+      refute_receive {:request_result, _}
+    end
+
+    test "a missing tag remains distinct from a failed request" do
+      opts = request_opts([{:ok, 404, [], ""}])
+      assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :not_found
+      assert_receive {:request_result, %{result: {:ok, 404, [], ""}}}
+    end
+
+    test "does not retry an authentication failure or treat it as a missing tag" do
+      opts = request_opts([{:ok, 401, [], ""}])
+      assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
+      assert :sys.get_state(opts[:rate_limiter]).sent_total == 1
+      assert_receive {:request_result, %{result: {:ok, 401, [], ""}}}
+    end
+
+    for body <- ["invalid json", "null", "[]", "{}"] do
+      test "returns unreadable for an unusable response: #{body}" do
+        opts = request_opts([{:ok, 200, [], unquote(body)}])
+        assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
+      end
+    end
+
+    test "leaves an existing manifest alone after lookup retries are exhausted" do
+      opts = request_opts(List.duplicate({:ok, 503, [], ""}, 10))
+      fetch = fn repo, tag -> DockerHub.fetch_tag(repo, tag, opts) end
+
+      refute Bob.Job.DockerManifest.publish?("erlang", "27.0", [{"amd64", @built_at}], fetch)
+    end
+
+    test "does not publish a partial manifest when a source lookup fails" do
+      opts = request_opts(List.duplicate({:error, :closed}, 10))
+      fetch = fn repo, tag -> DockerHub.fetch_tag(repo, tag, opts) end
+
+      assert Bob.Job.DockerManifest.get_archs("erlang", "27.0", fetch) == {:unreadable, "amd64"}
+      assert :sys.get_state(opts[:rate_limiter]).sent_total == 10
+    end
+  end
+
+  def request_event(_event, _measurements, metadata, pid) do
+    if self() == pid, do: send(pid, {:request_result, metadata})
+  end
+
+  defp request_opts(responses) do
+    responses = start_supervised!({Agent, fn -> responses end})
+    limiter = start_supervised!({DockerHub.RateLimiter, name: nil, window_ms: 0, park_ms: 0})
+    pid = self()
+
+    request = fn method, url, _headers, body, opts ->
+      send(pid, {:attempt, method, url, body, opts})
+      Agent.get_and_update(responses, fn [response | rest] -> {response, rest} end)
+    end
+
+    [request: request, rate_limiter: limiter, sleep: fn _duration -> :ok end]
+  end
+
   defp tag_payload(attrs) do
     Map.merge(
       %{

--- a/test/bob/docker_hub_test.exs
+++ b/test/bob/docker_hub_test.exs
@@ -54,7 +54,7 @@ defmodule Bob.DockerHubTest do
 
       :telemetry.attach(
         handler,
-        [:bob, :docker_hub, :request, :stop],
+        [:bob, :http, :request, :stop],
         &__MODULE__.request_event/4,
         self()
       )
@@ -68,7 +68,7 @@ defmodule Bob.DockerHubTest do
         [otp_app: :bob]
         |> Bob.PromEx.Plugins.OutboundHttp.event_metrics()
         |> Map.fetch!(:metrics)
-        |> Enum.find(&(&1.name == [:bob, :docker_hub, :request, :total]))
+        |> Enum.find(&(&1.name == [:bob, :prom_ex, :outbound_http, :request, :final, :total]))
 
       start_supervised!(
         {TelemetryMetricsPrometheus.Core,
@@ -96,24 +96,31 @@ defmodule Bob.DockerHubTest do
       end
 
       assert :sys.get_state(opts[:rate_limiter]).sent_total == 3
-      assert_receive {:request_result, %{method: :get, result: ^success}}
+      assert_receive {:request_result, %{host: "hub.docker.com", method: "GET", status: 200}}
       refute_receive {:request_result, _}
       refute_receive {:attempt, _, _, _, _}
 
       metrics = TelemetryMetricsPrometheus.Core.scrape(__MODULE__.Metrics)
-      assert metrics =~ ~s(bob_docker_hub_request_total{method="GET",status="200"} 1)
+
+      assert metrics =~
+               ~s(bob_prom_ex_outbound_http_request_final_total{host="hub.docker.com",method="GET",status="200"} 1)
+
       refute metrics =~ ~s(status="503")
       refute metrics =~ ~s(status="error")
     end
 
-    for failure <- [{:ok, 503, [], ""}, {:error, :timeout}] do
+    for {failure, status} <- [{{:ok, 503, [], ""}, 503}, {{:error, :timeout}, "error"}] do
       test "returns unreadable and records one result after exhausting #{inspect(failure)}" do
         failure = unquote(Macro.escape(failure))
         opts = request_opts(List.duplicate(failure, 10))
 
         assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
         for _ <- 1..10, do: assert_receive({:attempt, :get, _, _, _})
-        assert_receive {:request_result, %{method: :get, result: ^failure}}
+        status = unquote(status)
+
+        assert_receive {:request_result,
+                        %{host: "hub.docker.com", method: "GET", status: ^status}}
+
         refute_receive {:request_result, _}
         refute_receive {:attempt, _, _, _, _}
       end
@@ -124,7 +131,7 @@ defmodule Bob.DockerHubTest do
       opts = request_opts([{:ok, 429, [], ""}, success])
 
       assert DockerHub.paced_request(:delete, "https://hub.docker.com/tag", opts) == success
-      assert_receive {:request_result, %{method: :delete, result: ^success}}
+      assert_receive {:request_result, %{host: "hub.docker.com", method: "DELETE", status: 204}}
       assert :sys.get_state(opts[:rate_limiter]).sent_total == 2
       refute_receive {:request_result, _}
     end
@@ -135,21 +142,21 @@ defmodule Bob.DockerHubTest do
 
       assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
       assert :sys.get_state(opts[:rate_limiter]).sent_total == 6
-      assert_receive {:request_result, %{result: ^failure}}
+      assert_receive {:request_result, %{host: "hub.docker.com", status: 429}}
       refute_receive {:request_result, _}
     end
 
     test "a missing tag remains distinct from a failed request" do
       opts = request_opts([{:ok, 404, [], ""}])
       assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :not_found
-      assert_receive {:request_result, %{result: {:ok, 404, [], ""}}}
+      assert_receive {:request_result, %{status: 404}}
     end
 
     test "does not retry an authentication failure or treat it as a missing tag" do
       opts = request_opts([{:ok, 401, [], ""}])
       assert DockerHub.fetch_tag("hexpm/erlang", "27.0", opts) == :unreadable
       assert :sys.get_state(opts[:rate_limiter]).sent_total == 1
-      assert_receive {:request_result, %{result: {:ok, 401, [], ""}}}
+      assert_receive {:request_result, %{status: 401}}
     end
 
     for body <- ["invalid json", "null", "[]", "{}"] do

--- a/test/bob/http_test.exs
+++ b/test/bob/http_test.exs
@@ -38,6 +38,73 @@ defmodule Bob.HTTPTest do
              {:ok, 429, [{"x-ratelimit-remaining", "0"}], ""}
   end
 
+  describe "track_request/3" do
+    setup do
+      handler = {__MODULE__, make_ref()}
+
+      :telemetry.attach(
+        handler,
+        [:bob, :http, :request, :stop],
+        &__MODULE__.request_event/4,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "records one success after retries without exposing request or response contents" do
+      success = {:ok, 200, [{"set-cookie", "private"}], "private response"}
+      fun = counter([{:error, :closed}, {:ok, 503, [], ""}, success])
+      url = "https://user:password@api.github.com/private?token=secret"
+
+      assert HTTP.track_request(:get, url, fn ->
+               HTTP.retry("test", fun, sleep: fn _ -> :ok end)
+             end) == success
+
+      assert_receive {:final_request, metadata}
+      assert metadata == %{host: "api.github.com", method: "GET", status: 200}
+      refute_receive {:final_request, _}
+    end
+
+    for {failure, status} <- [
+          {{:ok, 503, [], ""}, 503},
+          {{:error, :timeout}, "error"},
+          {{:ok, 429, [], ""}, 429}
+        ] do
+      test "records one final failure after exhausting #{inspect(failure)}" do
+        failure = unquote(Macro.escape(failure))
+        fun = counter(List.duplicate(failure, 10))
+
+        assert HTTP.track_request(:post, "https://api.fastly.com/service/test/purge", fn ->
+                 HTTP.retry("test", fun, sleep: fn _ -> :ok end)
+               end) == failure
+
+        status = unquote(status)
+
+        assert_receive {:final_request, metadata}
+        assert metadata == %{host: "api.fastly.com", method: "POST", status: status}
+        refute_receive {:final_request, _}
+      end
+    end
+
+    test "records client errors as their final status" do
+      result = {:ok, 401, [], ""}
+      fun = counter([result])
+
+      assert HTTP.track_request("POST", "https://bob.hex.pm/api/queue/start", fn ->
+               HTTP.retry("test", fun)
+             end) == result
+
+      assert_receive {:final_request, %{host: "bob.hex.pm", method: "POST", status: 401}}
+      refute_receive {:final_request, _}
+    end
+  end
+
+  def request_event(_event, _measurements, metadata, pid) do
+    if self() == pid, do: send(pid, {:final_request, metadata})
+  end
+
   test "backoff grows exponentially but is capped" do
     assert HTTP.backoff(100, 0) == 100
     assert HTTP.backoff(100, 3) == 2_700

--- a/test/bob/job/docker_checker_test.exs
+++ b/test/bob/job/docker_checker_test.exs
@@ -548,6 +548,22 @@ defmodule Bob.Job.DockerCheckerTest do
   end
 
   describe "manifest/0" do
+    test "re-enqueues a manifest left unpublished by an unreadable tag" do
+      tag = "27.0-ubuntu-noble-20250101"
+      Artifacts.add_docker_tag("hexpm/erlang-amd64", tag, ["amd64"])
+      DockerChecker.manifest()
+      assert {:ok, {id, args}} = Bob.Queue.start(Bob.Job.DockerManifest)
+
+      assert Bob.Job.DockerManifest.get_archs("erlang", tag, fn _, _ -> :unreadable end) ==
+               {:unreadable, "amd64"}
+
+      Bob.Queue.success(id)
+
+      DockerChecker.manifest()
+      assert {:ok, {next_id, ^args}} = Bob.Queue.start(Bob.Job.DockerManifest)
+      refute next_id == id
+    end
+
     test "enqueues manifest jobs for per-arch tags missing from the manifest repo" do
       Artifacts.add_docker_tag("hexpm/erlang-amd64", "27.0-ubuntu-noble-20250101", ["amd64"])
       Artifacts.add_docker_tag("hexpm/erlang-arm64", "27.0-ubuntu-noble-20250101", ["arm64"])

--- a/test/bob/prom_ex/plugins/outbound_http_test.exs
+++ b/test/bob/prom_ex/plugins/outbound_http_test.exs
@@ -24,15 +24,7 @@ defmodule Bob.PromEx.Plugins.OutboundHttpTest do
     assert OutboundHttp.request_tags(%{request: request(), result: nil}).status == "unknown"
   end
 
-  test "tags final Docker Hub outcomes without including response bodies or URLs" do
-    assert OutboundHttp.docker_hub_tags(%{method: :get, result: {:ok, 200, [], "body"}}) ==
-             %{method: "GET", status: 200}
-
-    assert OutboundHttp.docker_hub_tags(%{method: :delete, result: {:error, :timeout}}) ==
-             %{method: "DELETE", status: "error"}
-  end
-
-  test "attaches to the Finch events the requests actually emit" do
+  test "attaches to attempt and final outcome events" do
     events =
       [otp_app: :bob]
       |> OutboundHttp.event_metrics()
@@ -41,7 +33,7 @@ defmodule Bob.PromEx.Plugins.OutboundHttpTest do
       |> Enum.map(& &1.event_name)
       |> Enum.uniq()
 
-    assert [:bob, :docker_hub, :request, :stop] in events
+    assert [:bob, :http, :request, :stop] in events
     assert [:finch, :request, :stop] in events
     assert [:finch, :request, :exception] in events
     assert [:finch, :queue, :stop] in events

--- a/test/bob/prom_ex/plugins/outbound_http_test.exs
+++ b/test/bob/prom_ex/plugins/outbound_http_test.exs
@@ -24,6 +24,14 @@ defmodule Bob.PromEx.Plugins.OutboundHttpTest do
     assert OutboundHttp.request_tags(%{request: request(), result: nil}).status == "unknown"
   end
 
+  test "tags final Docker Hub outcomes without including response bodies or URLs" do
+    assert OutboundHttp.docker_hub_tags(%{method: :get, result: {:ok, 200, [], "body"}}) ==
+             %{method: "GET", status: 200}
+
+    assert OutboundHttp.docker_hub_tags(%{method: :delete, result: {:error, :timeout}}) ==
+             %{method: "DELETE", status: "error"}
+  end
+
   test "attaches to the Finch events the requests actually emit" do
     events =
       [otp_app: :bob]
@@ -33,6 +41,7 @@ defmodule Bob.PromEx.Plugins.OutboundHttpTest do
       |> Enum.map(& &1.event_name)
       |> Enum.uniq()
 
+    assert [:bob, :docker_hub, :request, :stop] in events
     assert [:finch, :request, :stop] in events
     assert [:finch, :request, :exception] in events
     assert [:finch, :queue, :stop] in events


### PR DESCRIPTION
Route Docker Hub tag lookups through the shared rate limiter. When retries are exhausted or a response contains invalid JSON, return `:unreadable` so manifest generation preserves the existing image and the next checker run can retry.

Add `Bob.HTTP.track_request/3` and the generic `bob_prom_ex_outbound_http_request_final_total` counter, labeled by host, method, and final status. Docker Hub, GitHub, Fastly, and Bob master requests record one outcome after their complete retry operation. Docker Hub's outer 429 retry loop is included. The existing Finch counters retain individual attempts, and telemetry excludes URLs, credentials, headers, and response bodies.

Deploy the new metric before https://github.com/hexpm/hexpm-ops/pull/317, which selects Docker Hub through the host label and configures its tolerance in the alert rule.

Validated locally on Elixir 1.20.3/OTP 29 with the formatter, compilation with warnings as errors, and the full test suite: 453 tests passed, with one GNU `timeout` test excluded because the binary isn't installed. Regression coverage includes final outcomes after retry recovery and exhaustion, metric export, manifest preservation, and re-enqueueing skipped manifests.
